### PR TITLE
Browser translation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#FFFFFF" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Blank Wallet</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-  </body>
+<html lang="en" translate="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#FFFFFF" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <meta name="google" content="notranslate">
+  <title>Blank Wallet</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
 </html>


### PR DESCRIPTION
- Added HTML tags to prevent browser translation of the extension. This happens when the wallet is opened on a window ie: triggering a transaction from a dApp and having Chrome set on a different language than English.