### PR TITLE
Removed CSP for unsafe_eval fix

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,7 +14,6 @@
     "default_popup": "popup.html",
     "default_title": "Blank Wallet"
   },
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "description": "The most private, non-custodial ethereum wallet",
   "homepage_url": "https://www.goblank.io/",
   "icons": {


### PR DESCRIPTION
To prevent using the unsafe-eval flag on the CSP, a forked modified version of snarkjs is presented below
https://github.com/Blank-Wallet/snarkjs

The extension _manifest.json_ file was updated to remove the CSP to stick with the default one.

