### PR TITLE
Added wasm-eval CSP

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -21,6 +21,7 @@
         "48": "icons/icon-48.png",
         "128": "icons/icon-128.png"
     },
+    "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
     "manifest_version": 2,
     "name": "Blank Wallet",
     "permissions": [


### PR DESCRIPTION
# Summary
Fixes an error related with:

https://bugs.chromium.org/p/chromium/issues/detail?id=1173354&q=%22Wasm%20code%20generation%20disallowed%20by%20embedder%22&can=2#c27

_"As of M97, the appropriate way to enable wasm is to use wasm-unsafe-eval.
However, the previous mode of using unsafe-eval should continue to work.
There is a special CSP source for extensions: wasm-eval. As far as I know,
this has not changed.
However, what has changed is workers. It used to be the case that CSP was
ignored in workers for wasm. This is no longer true: CSP is now being
enforced for workers as well as the main thread."_

So in order to run the required wasm scripts for the privacy feature, this PR adds the above mentioned policy.