### PR TITLE
Allow load in all frames

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,8 @@
         {
             "js": ["content.js"],
             "matches": ["http://*/*", "https://*/*"],
-            "run_at": "document_start"
+            "run_at": "document_start",
+            "all_frames": true
         }
     ],
     "browser_action": {


### PR DESCRIPTION
## Description

This PR solves an issue in which the ethereum and web3 properties weren't defined in certain scopes of a site and so our wallet wasn't being detected by the dapps if the detection/interaction wasn't running in the main frame.