### PR TITLE
Add test tags

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,3 +137,4 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_TAGS: puppeteer,extension


### PR DESCRIPTION
The aim of this PR is to run only extension e2e until we have the staking site deployed on production