### PR TITLE
feat: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,14 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @ImanH @devops
+*       @ImanH @block-wallet/devops
 
 /packages/background @block-wallet/backgroundreviewers
 /packages/ui @block-wallet/uireviewers
 /packages/provider @block-wallet/providerreviewers
 
-/.github/ @devops
-Makefile @devops
+/.github/ @block-wallet/devops
+Makefile @block-wallet/devops
 
 package.json @block-wallet/releasereviewers
 release-notes.json  @block-wallet/releasereviewers


### PR DESCRIPTION
Add teams as code owners in some folders. This means that the team will be added as a reviewer in the PR and it will need its approval. 