### PR TITLE
Validate commits messages and branch names

### DIFF
--- a/.github/workflows/convention.yml
+++ b/.github/workflows/convention.yml
@@ -7,8 +7,6 @@ on:
 
   repository_dispatch:
     types: [automation]
-env:
-  CONVENTION: "^(chore|docs|feat|fix|refactor|style|test)"
 
 jobs:
   validation:
@@ -18,7 +16,7 @@ jobs:
       - name: Validate commit messages
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^(chore|docs|feat|fix|refactor|style|test|release){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
+          pattern: '^(chore|docs|feat|fix|refactor|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
           flags: "gm"
           excludeDescription: "true"
           excludeTitle: "true"


### PR DESCRIPTION
# Description

Added a pipeline triggered when a PR and/or its commits are targeting master branch that checks the commits messages and branch name.

## Commits messages

![image](https://user-images.githubusercontent.com/98833290/176195491-23205ccd-aff1-4d43-89e4-3733c96fe05e.png)

![image](https://user-images.githubusercontent.com/98833290/176195603-3b953ba8-0f92-4787-b7a7-7d43a8f2b0c2.png)

![image](https://user-images.githubusercontent.com/98833290/176195764-b25d59b0-7793-404b-aa41-f8eef94d961c.png)


## Branch name

![image](https://user-images.githubusercontent.com/98833290/176195884-e43bac54-da77-48a2-b00e-0bfb48cf7e59.png)

![image](https://user-images.githubusercontent.com/98833290/176195977-5586541e-1815-404a-897d-19603f1e7701.png)
