### PR TITLE
Add PR and issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,27 @@
+
+---
+name: Custom issue template
+about: Multi purpose issue template for bug reports and feature requests
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## I'm submitting a ...
+
+- [ ] bug report
+- [ ] feature request
+
+## What is the current behavior?
+
+## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
+
+## What is the expected behavior?
+
+## What is the motivation / use case for changing the behavior?
+
+## Please tell us about your environment:
+
+Extension version: 
+Browser:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Name of the feature/issue
+
+## Description
+
+## Type of change
+
+Click the correct/s option/s
+
+- [ ]  Bug fix (non-breaking change which fixes an issue)
+- [ ]  New feature (non-breaking change which adds functionality)
+- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ]  This change requires a documentation update


### PR DESCRIPTION
# Description

Add both templates according to the convention. New issues and PR will report in the channel #blockwallet-monorepo