### PR TITLE
feat: Show incoming bridge placeholder in destination network

### DIFF
--- a/packages/background/src/controllers/ActivityListController.ts
+++ b/packages/background/src/controllers/ActivityListController.ts
@@ -1,7 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { parseUnits } from 'ethers/lib/utils';
 import { BaseController } from '../infrastructure/BaseController';
+import { BridgeStatus } from '../utils/bridgeApi';
 import { Network } from '../utils/constants/networks';
+import { transactionToIncomingBridgeTransactionPlaceholder } from '../utils/incomingBridgePlaceholder';
 import {
     BlankDepositController,
     PendingWithdrawal,
@@ -89,7 +91,45 @@ export class ActivityListController extends BaseController<IActivityListState> {
             selectedAddress
         );
 
-        const incomingBridgeTransactions =
+        //Incoming bridges that may or may not be converted into an incoming transaction for this network and account.
+        //If the bridge is completed successfully, then it will appear as a trasnaction gathered by the BridgingController.
+        //if the bridge failed, it will be filtered by the  tx.bridgeParams.status === BridgeStatus.PENDING condition
+        const pendingIncomingBridgePlaceholders =
+            this._transactionsController.store
+                .getState()
+                .transactions.filter((tx) => {
+                    const { bridgeParams, transactionCategory, status } = tx;
+                    if (!bridgeParams || !bridgeParams.status) {
+                        return false;
+                    }
+
+                    return (
+                        // Sending tx category is Bridge
+                        transactionCategory === TransactionCategories.BRIDGE &&
+                        // Destination chain transaction is the selected one
+                        Number(tx.bridgeParams?.toChainId) ===
+                            Number(this._networkController.network.chainId) &&
+                        //There is no receiving hash YET
+                        !bridgeParams.receivingTxHash &&
+                        // Bridge is in PENDING or NOT FOUND (considered PENDING) status.
+                        [BridgeStatus.PENDING, BridgeStatus.NOT_FOUND].includes(
+                            bridgeParams.status
+                        ) &&
+                        // Sending transaction is submitted or confirmed
+                        [
+                            TransactionStatus.SUBMITTED,
+                            TransactionStatus.CONFIRMED,
+                        ].includes(status)
+                    );
+                })
+                .map((tx) =>
+                    transactionToIncomingBridgeTransactionPlaceholder(
+                        tx,
+                        this._networkController.network.chainId
+                    )
+                );
+
+        const confirmedIncomingBridgeTransactions =
             this.parseBridgeReceivingTransactions(
                 network.chainId,
                 selectedAddress
@@ -102,7 +142,7 @@ export class ActivityListController extends BaseController<IActivityListState> {
         // Concat all and order by time
         const confirmedConcated = confirmedTransactions
             .concat(confirmedWithdrawals)
-            .concat(incomingBridgeTransactions)
+            .concat(confirmedIncomingBridgeTransactions)
             .concat(watchedTransactions)
             .filter(
                 (t1, index, self) =>
@@ -155,6 +195,7 @@ export class ActivityListController extends BaseController<IActivityListState> {
         // Pendings ordered by time descending
         const pending = pendingWithdrawals
             .concat(pendingTransactions)
+            .concat(pendingIncomingBridgePlaceholders)
             .sort((a, b) => a.time - b.time)
             .map((c: TransactionMeta) => {
                 return this.transactionSymbolTransformation(c);

--- a/packages/background/src/controllers/ActivityListController.ts
+++ b/packages/background/src/controllers/ActivityListController.ts
@@ -91,43 +91,9 @@ export class ActivityListController extends BaseController<IActivityListState> {
             selectedAddress
         );
 
-        //Incoming bridges that may or may not be converted into an incoming transaction for this network and account.
-        //If the bridge is completed successfully, then it will appear as a trasnaction gathered by the BridgingController.
-        //if the bridge failed, it will be filtered by the  tx.bridgeParams.status === BridgeStatus.PENDING condition
+        //Pending bridges placeholders for the current network
         const pendingIncomingBridgePlaceholders =
-            this._transactionsController.store
-                .getState()
-                .transactions.filter((tx) => {
-                    const { bridgeParams, transactionCategory, status } = tx;
-                    if (!bridgeParams || !bridgeParams.status) {
-                        return false;
-                    }
-
-                    return (
-                        // Sending tx category is Bridge
-                        transactionCategory === TransactionCategories.BRIDGE &&
-                        // Destination chain transaction is the selected one
-                        Number(tx.bridgeParams?.toChainId) ===
-                            Number(this._networkController.network.chainId) &&
-                        //There is no receiving hash YET
-                        !bridgeParams.receivingTxHash &&
-                        // Bridge is in PENDING or NOT FOUND (considered PENDING) status.
-                        [BridgeStatus.PENDING, BridgeStatus.NOT_FOUND].includes(
-                            bridgeParams.status
-                        ) &&
-                        // Sending transaction is submitted or confirmed
-                        [
-                            TransactionStatus.SUBMITTED,
-                            TransactionStatus.CONFIRMED,
-                        ].includes(status)
-                    );
-                })
-                .map((tx) =>
-                    transactionToIncomingBridgeTransactionPlaceholder(
-                        tx,
-                        this._networkController.network.chainId
-                    )
-                );
+            this._parsePendingIncomingBridgePlaceholders();
 
         const confirmedIncomingBridgeTransactions =
             this.parseBridgeReceivingTransactions(
@@ -400,6 +366,54 @@ export class ActivityListController extends BaseController<IActivityListState> {
             .map(mapFc);
 
         return { confirmed, pending };
+    }
+
+    /**
+     * _parsePendingIncomingBridgePlaceholders
+     *
+     *  Incoming bridges that may or may not be converted into an incoming transaction for this network and account.
+     *  - If the bridge is completed successfully, then it will appear as a trasnaction gathered by the BridgingController.
+     *  - If the bridge failed, it will be filtered by the  tx.bridgeParams.status === BridgeStatus.PENDING condition
+     *
+     * @returns pending bridges placeholders for the destination network
+     */
+    private _parsePendingIncomingBridgePlaceholders(): TransactionMeta[] {
+        const pendingIncomingBridgePlaceholders =
+            this._transactionsController.store
+                .getState()
+                .transactions.filter((tx) => {
+                    const { bridgeParams, transactionCategory, status } = tx;
+                    if (!bridgeParams || !bridgeParams.status) {
+                        return false;
+                    }
+
+                    return (
+                        // Sending tx category is Bridge
+                        transactionCategory === TransactionCategories.BRIDGE &&
+                        // Destination chain transaction is the selected one
+                        Number(tx.bridgeParams?.toChainId) ===
+                            Number(this._networkController.network.chainId) &&
+                        //There is no receiving hash YET
+                        !bridgeParams.receivingTxHash &&
+                        // Bridge is in PENDING or NOT FOUND (considered PENDING) status.
+                        [BridgeStatus.PENDING, BridgeStatus.NOT_FOUND].includes(
+                            bridgeParams.status
+                        ) &&
+                        // Sending transaction is submitted or confirmed
+                        [
+                            TransactionStatus.SUBMITTED,
+                            TransactionStatus.CONFIRMED,
+                        ].includes(status)
+                    );
+                })
+                .map((tx) =>
+                    transactionToIncomingBridgeTransactionPlaceholder(
+                        tx,
+                        this._networkController.network.chainId
+                    )
+                );
+
+        return pendingIncomingBridgePlaceholders;
     }
 
     /**

--- a/packages/background/src/controllers/transactions/utils/types.ts
+++ b/packages/background/src/controllers/transactions/utils/types.ts
@@ -169,6 +169,10 @@ export enum TransactionCategories {
     EXCHANGE = 'exchange',
     BRIDGE = 'bridge',
     INCOMING_BRIDGE = 'incoming_bridge',
+    // Category that temporarely represents receiving transactions in a bridge operation:
+    // - These transactions are placeholders for the real transaction that will replace them.
+    // - These transactions are not persisted in the state, they are only meant to be shown in the Activity list.
+    INCOMING_BRIDGE_PLACEHOLDER = 'incoming_bridge_placeholder',
 }
 
 /**

--- a/packages/background/src/utils/incomingBridgePlaceholder.ts
+++ b/packages/background/src/utils/incomingBridgePlaceholder.ts
@@ -1,0 +1,29 @@
+import { BigNumber } from 'ethers';
+import {
+    TransactionCategories,
+    TransactionMeta,
+    TransactionStatus,
+} from '../controllers/transactions/utils/types';
+
+const transactionToIncomingBridgeTransactionPlaceholder = (
+    sendingTx: TransactionMeta,
+    chainId: number
+): TransactionMeta => {
+    return {
+        ...sendingTx,
+        id: '',
+        transactionParams: {},
+        chainId,
+        transactionCategory: TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER,
+        transferType: {
+            amount: BigNumber.from(sendingTx.bridgeParams!.toTokenAmount),
+            currency: sendingTx.bridgeParams!.toToken.symbol,
+            decimals: sendingTx.bridgeParams!.toToken.decimals,
+        },
+        status: TransactionStatus.SUBMITTED,
+        confirmationTime: undefined,
+        methodSignature: undefined,
+    };
+};
+
+export { transactionToIncomingBridgeTransactionPlaceholder };

--- a/packages/ui/src/components/transactions/TransactionItem.tsx
+++ b/packages/ui/src/components/transactions/TransactionItem.tsx
@@ -165,6 +165,9 @@ const transactionIcons = {
     [TransactionCategories.INCOMING_BRIDGE]: (
         <GiSuspensionBridge size="1.5rem" />
     ),
+    [TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER]: (
+        <GiSuspensionBridge size="1.5rem" />
+    ),
 }
 
 const failedStatuses = [

--- a/packages/ui/src/components/transactions/TransactionItem.tsx
+++ b/packages/ui/src/components/transactions/TransactionItem.tsx
@@ -69,6 +69,7 @@ const transactionMessages = {
     [TransactionCategories.EXCHANGE]: "BlockWallet Swap",
     [TransactionCategories.BRIDGE]: "BlockWallet Bridge",
     [TransactionCategories.INCOMING_BRIDGE]: "Incoming Bridge",
+    [TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER]: "Incoming Bridge",
 }
 
 const pendingTransactionMessages: { [x: string]: string } = {
@@ -455,6 +456,7 @@ const TransactionItem: React.FC<{
             case TransactionCategories.TOKEN_METHOD_INCOMING_TRANSFER:
             case TransactionCategories.BLANK_WITHDRAWAL:
             case TransactionCategories.INCOMING_BRIDGE:
+            case TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER:
                 return "+"
 
             default:
@@ -595,6 +597,8 @@ const TransactionItem: React.FC<{
 
                         {status === TransactionStatus.SUBMITTED &&
                             metaType === MetaType.REGULAR &&
+                            transactionCategory !==
+                                TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER &&
                             !isBlankWithdraw && (
                                 <div className="mt-2">
                                     {blankDepositId &&

--- a/packages/ui/src/components/transactions/TransactionItem.tsx
+++ b/packages/ui/src/components/transactions/TransactionItem.tsx
@@ -43,17 +43,12 @@ import { useSelectedNetwork } from "../../context/hooks/useSelectedNetwork"
 import AppIcon from "./../icons/AppIcon"
 import TransactionDetails from "./TransactionDetails"
 import { formatName } from "../../util/formatAccount"
-import {
-    getDepositTransactionInfo,
-    RichedTransactionMeta,
-} from "../../util/transactionUtils"
+import { RichedTransactionMeta } from "../../util/transactionUtils"
 import Dots from "../loading/LoadingDots"
 import useContextMenu from "../../util/hooks/useContextMenu"
 import { getBridgePendingMessage } from "../../util/bridgeTransactionUtils"
 import useCurrencyFromatter from "../../util/hooks/useCurrencyFormatter"
 import useGetBridgeDetails from "../../util/hooks/useGetBridgeDetails"
-
-const DEFAULT_TORNADO_CONFIRMATION = 4
 
 const transactionMessages = {
     [TransactionCategories.BLANK_DEPOSIT]: "Privacy Pool Deposit",
@@ -402,7 +397,6 @@ const TransactionItem: React.FC<{
     index: number
 }> = ({ index, transaction }) => {
     const {
-        blankDepositId,
         transactionParams: { value, hash },
         transactionCategory,
         methodSignature,
@@ -412,7 +406,6 @@ const TransactionItem: React.FC<{
         submittedTime,
         transferType,
         metaType,
-        transactionReceipt,
         id,
         flashbots,
         isQueued,
@@ -424,11 +417,8 @@ const TransactionItem: React.FC<{
     const history: any = useOnMountHistory()
     const formatter = useCurrencyFromatter()
 
-    const {
-        nativeCurrency: networkNativeCurrency,
-        defaultNetworkLogo,
-        tornadoIntervals,
-    } = useSelectedNetwork()
+    const { nativeCurrency: networkNativeCurrency, defaultNetworkLogo } =
+        useSelectedNetwork()
 
     const [hasDetails, setHasDetails] = useState(false)
 
@@ -477,11 +467,6 @@ const TransactionItem: React.FC<{
         label,
         valueLabel
     )
-    const depositTransactionInfo = getDepositTransactionInfo({
-        transactionReceipt,
-        blankDepositId,
-        status,
-    })
 
     const contextMenuRef = useRef(null)
 
@@ -498,6 +483,13 @@ const TransactionItem: React.FC<{
         transfer.decimals,
         transfer.currency === networkNativeCurrency.symbol.toUpperCase()
     )
+
+    const canSpeedUpOrCancel =
+        status === TransactionStatus.SUBMITTED &&
+        metaType === MetaType.REGULAR &&
+        transactionCategory !==
+            TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER &&
+        !isBlankWithdraw
 
     return (
         <>
@@ -598,82 +590,46 @@ const TransactionItem: React.FC<{
                             bridgeParams
                         )}
 
-                        {status === TransactionStatus.SUBMITTED &&
-                            metaType === MetaType.REGULAR &&
-                            transactionCategory !==
-                                TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER &&
-                            !isBlankWithdraw && (
-                                <div className="mt-2">
-                                    {blankDepositId &&
-                                    depositTransactionInfo.isAwaitingForConfirmation ? (
-                                        <div className="group relative self-start">
-                                            <div className="flex flex-row items-center">
-                                                <i className="text-gray-500">
-                                                    {`${
-                                                        depositTransactionInfo.confirmations
-                                                    } of ${
-                                                        tornadoIntervals?.depositConfirmations ||
-                                                        DEFAULT_TORNADO_CONFIRMATION
-                                                    } blocks confirmed`}
-                                                    <Dots />
-                                                </i>
-                                            </div>
-                                            <Tooltip
-                                                className="translate-x-1.5 !w-52 !break-word !whitespace-normal"
-                                                content={
-                                                    <span>
-                                                        {`BlockWallet waits ${
-                                                            tornadoIntervals?.depositConfirmations ||
-                                                            DEFAULT_TORNADO_CONFIRMATION
-                                                        } blocks to mark the deposits as confirmed`}
-                                                    </span>
-                                                }
-                                            />
-                                        </div>
-                                    ) : (
-                                        <>
-                                            <button
-                                                type="button"
-                                                className={classnames(
-                                                    "rounded-md cursor-pointer text-blue-500 border-current border p-1 font-bold hover:bg-blue-500 hover:text-white transition-colors",
-                                                    isQueued
-                                                        ? "opacity-50 pointer-events-none"
-                                                        : ""
-                                                )}
-                                                disabled={isQueued}
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    history.push({
-                                                        pathname:
-                                                            "/transaction/speedUp",
-                                                        state: {
-                                                            txId: id,
-                                                        },
-                                                    })
-                                                }}
-                                            >
-                                                Speed up
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className="ml-1.5 border p-1 rounded-md cursor-pointer text-gray-500 border-current font-bold hover:bg-gray-500 hover:text-white transition-colors"
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    history.push({
-                                                        pathname:
-                                                            "/transaction/cancel",
-                                                        state: {
-                                                            txId: id,
-                                                        },
-                                                    })
-                                                }}
-                                            >
-                                                Cancel
-                                            </button>
-                                        </>
+                        {canSpeedUpOrCancel && (
+                            <div className="mt-2">
+                                <button
+                                    type="button"
+                                    className={classnames(
+                                        "rounded-md cursor-pointer text-blue-500 border-current border p-1 font-bold hover:bg-blue-500 hover:text-white transition-colors",
+                                        isQueued
+                                            ? "opacity-50 pointer-events-none"
+                                            : ""
                                     )}
-                                </div>
-                            )}
+                                    disabled={isQueued}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        history.push({
+                                            pathname: "/transaction/speedUp",
+                                            state: {
+                                                txId: id,
+                                            },
+                                        })
+                                    }}
+                                >
+                                    Speed up
+                                </button>
+                                <button
+                                    type="button"
+                                    className="ml-1.5 border p-1 rounded-md cursor-pointer text-gray-500 border-current font-bold hover:bg-gray-500 hover:text-white transition-colors"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        history.push({
+                                            pathname: "/transaction/cancel",
+                                            state: {
+                                                txId: id,
+                                            },
+                                        })
+                                    }}
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        )}
                     </div>
 
                     {/* Amount */}

--- a/packages/ui/src/context/commTypes.ts
+++ b/packages/ui/src/context/commTypes.ts
@@ -244,6 +244,8 @@ export enum TransactionCategories {
     EXCHANGE = "exchange",
     BRIDGE = "bridge",
     INCOMING_BRIDGE = "incoming_bridge",
+    // Category that temporarely represents receiving transactions in a bridge operation:
+    INCOMING_BRIDGE_PLACEHOLDER = "incoming_bridge_placeholder",
 }
 
 export enum PendingWithdrawalStatus {

--- a/packages/ui/src/util/transactionUtils.ts
+++ b/packages/ui/src/util/transactionUtils.ts
@@ -3,7 +3,7 @@ import {
     TransactionMeta,
     uiTransactionParams,
 } from "@block-wallet/background/controllers/transactions/utils/types"
-import { TransactionStatus } from "../context/commTypes"
+import { TransactionCategories, TransactionStatus } from "../context/commTypes"
 import { BigNumber } from "ethers"
 import { DappRequestSigningStatus } from "../context/hooks/useDappRequest"
 export interface RichedTransactionMeta extends TransactionMeta {
@@ -21,23 +21,38 @@ export const flagQueuedTransactions = (
     }
     const lowestPendingNonce = pendingTransactions
         .filter((transaction) => {
-            return transaction.status === TransactionStatus.SUBMITTED
+            return (
+                transaction.status === TransactionStatus.SUBMITTED &&
+                transaction.transactionCategory !==
+                    TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER
+            )
         })
         .reduce((lowest, current) => {
-            const currentNonce = current.transactionParams.nonce || -1
-            if (lowest === -1 || currentNonce < lowest) {
+            const currentNonce =
+                current.transactionParams.nonce ?? Number.MAX_VALUE
+            if (currentNonce < lowest) {
                 return currentNonce
             }
             return lowest
-        }, -1)
+        }, Number.MAX_VALUE)
 
     return pendingTransactions.map((transaction) => {
-        const transactionNonce = transaction.transactionParams.nonce || -1
+        const transactionNonce = transaction.transactionParams.nonce
+        if (!transactionNonce) {
+            return {
+                ...transaction,
+                isQueued: false,
+            }
+        }
         const isPendingState =
             transaction.status === TransactionStatus.SUBMITTED
         return {
             ...transaction,
-            isQueued: isPendingState && transactionNonce > lowestPendingNonce,
+            isQueued:
+                transaction.transactionCategory !==
+                    TransactionCategories.INCOMING_BRIDGE_PLACEHOLDER &&
+                isPendingState &&
+                transactionNonce > lowestPendingNonce,
         }
     })
 }


### PR DESCRIPTION
# Name of the feature/issue
Bridging

## Description
This pr meant to show the incoming bridging transactions before we already know the destination transaction hash so that the user can see the "Incoming bridge" transaction in their activity list while it is pending.

Click the correct/s option/s

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

https://user-images.githubusercontent.com/22504074/192754076-6d2fe986-b1e5-43e9-9927-e7c5bf6a1e4b.mov


