### PR TITLE
[Fix] isNil logic 

### DIFF
--- a/packages/ui/src/components/transactions/TransactionItem.tsx
+++ b/packages/ui/src/components/transactions/TransactionItem.tsx
@@ -112,7 +112,10 @@ const getPendingTransactionMessage = (
     return message
 }
 
-const getTransactionItemStyles = (label: string, txValue: string) => {
+const getTransactionItemStyles = (
+    label: string = "Transaction",
+    txValue: string
+) => {
     let formattedLabel = label
 
     // We're letting both containers to grow based on content but with a limit to keep them inside the container
@@ -121,7 +124,7 @@ const getTransactionItemStyles = (label: string, txValue: string) => {
 
     // If label and value are both long, we crop the label prioritizing the value.
     //Example: Privacy Pool Witdraw X.XXXXX
-    if (label.length > 18 && txValue.length > 7) {
+    if (label.length > 18 && txValue?.length > 7) {
         formattedLabel = formatName(label, 20)
     }
 

--- a/packages/ui/src/util/account.ts
+++ b/packages/ui/src/util/account.ts
@@ -46,7 +46,7 @@ export const isInternalAccount = (accountType: AccountType): boolean => {
 }
 
 export const isActiveAccount = (accountInfo: AccountInfo): boolean => {
-    return accountInfo.status.toString() === AccountStatus.ACTIVE
+    return accountInfo.status?.toString() === AccountStatus.ACTIVE
 }
 
 /**

--- a/packages/ui/src/util/isNil.ts
+++ b/packages/ui/src/util/isNil.ts
@@ -1,5 +1,5 @@
 const isNil = (value: any) => {
-    return value !== null && value !== undefined
+    return typeof value === "undefined" || value === null || value === undefined
 }
 
 export default isNil


### PR DESCRIPTION
# Name of the feature/issue
Fix a bug in the Transaction details when trying to show the nonce of a non-mined tx.

## Description
The isNil check was not implemented properly. Also, some corner cases were handled in this PR, like when we cannot get a transaction label (due to using an old build with newer transaction categories)

## Type of change

Click the correct/s option/s

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update
