### PR TITLE
Feat/improve accounts switching accessibility

### DIFF
--- a/packages/ui/src/components/account/AccountMenu.tsx
+++ b/packages/ui/src/components/account/AccountMenu.tsx
@@ -7,6 +7,7 @@ import AccountDisplay from "./AccountDisplay"
 import exportIcon from "../../assets/images/icons/export.svg"
 import trashBinIcon from "../../assets/images/icons/trash_bin.svg"
 import openExternal from "../../assets/images/icons/open_external.svg"
+import switchIcon from "../../assets/images/icons/refresh.svg"
 import qrIcon from "../../assets/images/icons/qr_icon.svg"
 import sites from "../../assets/images/icons/connected_sites.svg"
 import editIcon from "../../assets/images/icons/pencil.svg"
@@ -56,6 +57,11 @@ const AccountMenu = () => {
                 "address"
             ),
         },
+        {
+            icon: switchIcon,
+            label: "Switch Accounts",
+            to: "/accounts",
+        },
     ]
 
     const disabledOptions: { [k: string]: boolean } = {}
@@ -65,14 +71,14 @@ const AccountMenu = () => {
         disabledOptions[exportAccountDataLabel] = true
         tooltipOptions[exportAccountDataLabel] =
             "Not available for Hardware Wallets accounts."
-        options.push({
+        options.splice(options.length-1, 0, {
             icon: trashBinIcon,
             label: removeHWLabel,
             to: undefined,
             next: () => {
                 openHardwareRemove()
             },
-        })
+        });
     }
 
     return (
@@ -90,7 +96,7 @@ const AccountMenu = () => {
                 />
             }
         >
-            <div className="flex flex-col p-6 space-y-8 text-sm text-gray-500">
+            <div className="flex flex-col p-6 space-y-4 text-sm text-gray-500">
                 <div className="flex flex-col">
                     <AccountDisplay
                         account={account}

--- a/packages/ui/src/routes/PopupPage.tsx
+++ b/packages/ui/src/routes/PopupPage.tsx
@@ -167,17 +167,32 @@ const PopupPage = () => {
             >
                 <div className="flex flex-row items-center justify-between w-full">
                     <div className="flex flex-row items-center space-x-3">
-                        <Link
-                            to="/accounts"
-                            className="transition duration-300"
-                            draggable={false}
-                            data-testid="navigate-account-link"
-                        >
-                            <AccountIcon
-                                className="w-8 h-8 transition-transform duration-200 ease-in transform hover:rotate-180"
-                                fill={getAccountColor(account?.address)}
-                            />
-                        </Link>
+                        <div className="relative flex flex-col items-start group">
+                            <Link
+                                to="/accounts"
+                                className="transition duration-300"
+                                draggable={false}
+                                data-testid="navigate-account-link"
+                            >
+                                <AccountIcon
+                                    className="w-8 h-8 transition-transform duration-200 ease-in transform hover:rotate-180"
+                                    fill={getAccountColor(account?.address)}
+                                />
+                            </Link>
+                            {/* Switch Account Icon ToolTip */}
+                            <div
+                                className={classnames(
+                                    "pointer-events-none absolute bottom-0 -mb-2 transform translate-y-full p-2 rounded-md text-xs font-bold bg-gray-900 text-white whitespace-nowrap",
+                                    "invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-200"
+                                )}
+                                style={{ width: "fit-content", height: "fit-content", zIndex: 100 }}
+                            >
+                                <div className="relative">
+                                    <div className="border-t-4 border-r-4 border-gray-900 absolute top-0 left-2 w-2 h-2 -mt-2.5 transform -rotate-45 -translate-x-1/2" />                                    
+                                        <span>Switch Accounts</span>
+                                    </div>
+                                </div>
+                            </div>
                         <div className="flex flex-row items-center space-x-1">
                             <AccountDisplay />
                             <Link

--- a/packages/ui/src/routes/account/AccountsPage.tsx
+++ b/packages/ui/src/routes/account/AccountsPage.tsx
@@ -21,7 +21,6 @@ const AccountsPage = () => {
             header={
                 <PopupHeader
                     title="My Accounts"
-                    onBack={() => history.push("/")}
                 />
             }
         >


### PR DESCRIPTION
# Name of the feature/issue
Improve accounts switching accessibility

## Description
The switch account view is only accessible by clicking the account icon located on the header of the home page. For new users is a bit hard to guess how that works, so this is improved by:

- Adding a tooltip to that icon.
- Adding a new button to the Account page that routes to the accounts selection page.

## Type of change

Click the correct/s option/s

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update
