### PR TITLE
Fix/node validation

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@block-wallet/background",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "private": true,
     "dependencies": {
         "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.14",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -3,7 +3,7 @@
     "version": "0.7.2",
     "private": true,
     "dependencies": {
-        "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.16",
+        "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.17",
         "@block-wallet/circomlib": "^0.0.21",
         "@block-wallet/eth-ledger-bridge-keyring": "https://github.com/block-wallet/eth-ledger-bridge-keyring",
         "@block-wallet/explorer-link": "https://github.com/block-wallet/explorer-link#v2.2.2",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -3,7 +3,7 @@
     "version": "0.7.2",
     "private": true,
     "dependencies": {
-        "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.14",
+        "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.16",
         "@block-wallet/circomlib": "^0.0.21",
         "@block-wallet/eth-ledger-bridge-keyring": "https://github.com/block-wallet/eth-ledger-bridge-keyring",
         "@block-wallet/explorer-link": "https://github.com/block-wallet/explorer-link#v2.2.2",

--- a/packages/background/src/infrastructure/stores/migrator/migrations/index.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/index.ts
@@ -42,6 +42,7 @@ import migration40 from './migration-40';
 import migration41 from './migration-41';
 import migration42 from './migration-42';
 import migration43 from './migration-43';
+import migration44 from './migration-44';
 
 const migrations: IMigration[] = [
     migration01,
@@ -87,5 +88,6 @@ const migrations: IMigration[] = [
     migration41,
     migration42,
     migration43,
+    migration44,
 ];
 export default (): IMigration[] => migrations;

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-43.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-43.ts
@@ -36,8 +36,8 @@ export default {
             ens: false,
             showGasLevels: true,
             rpcUrls: [`https://zksync2-testnet.zksync.dev`],
-            blockExplorerUrls: ['https://zksync2-testnet.zkscan.io'],
-            blockExplorerName: 'zkScan',
+            blockExplorerUrls: ['https://explorer.zksync.io/'],
+            blockExplorerName: 'zkSync Explorer',
             actionsTimeIntervals: { ...TESTNET_TIME_INTERVALS_DEFAULT_VALUES },
             tornadoIntervals: {
                 depositConfirmations: DEFAULT_TORNADO_CONFIRMATION,

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-44.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-44.ts
@@ -1,0 +1,29 @@
+import { BlankAppState } from '@block-wallet/background/utils/constants/initialState';
+import { IMigration } from '../IMigration';
+
+/**
+ * This migration fixes the symbol of BSC Testnet
+ */
+export default {
+    migrate: async (persistedState: BlankAppState) => {
+        const { availableNetworks } = persistedState.NetworkController;
+        const updatedNetworks = { ...availableNetworks };
+
+        updatedNetworks.BSC_TESTNET = {
+            ...updatedNetworks.BSC_TESTNET,
+            rpcUrls: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
+            nativeCurrency: {
+                ...updatedNetworks.BSC_TESTNET.nativeCurrency,
+                symbol: 'tBNB',
+            },
+        };
+        return {
+            ...persistedState,
+            NetworkController: {
+                ...persistedState.NetworkController,
+                availableNetworks: { ...updatedNetworks },
+            },
+        };
+    },
+    version: '0.7.2',
+} as IMigration;

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-44.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-44.ts
@@ -2,7 +2,7 @@ import { BlankAppState } from '@block-wallet/background/utils/constants/initialS
 import { IMigration } from '../IMigration';
 
 /**
- * This migration fixes the symbol of BSC Testnet
+ * This migration fixes the symbol and RPC url of BSC Testnet
  */
 export default {
     migrate: async (persistedState: BlankAppState) => {

--- a/packages/background/src/utils/constants/networks.ts
+++ b/packages/background/src/utils/constants/networks.ts
@@ -578,8 +578,8 @@ export const INITIAL_NETWORKS: Networks = {
         ens: false,
         showGasLevels: true,
         rpcUrls: [`https://zksync2-testnet.zksync.dev`],
-        blockExplorerUrls: ['https://zksync2-testnet.zkscan.io'],
-        blockExplorerName: 'zkScan',
+        blockExplorerUrls: ['https://explorer.zksync.io/'],
+        blockExplorerName: 'zkSync Explorer',
         actionsTimeIntervals: { ...TESTNET_TIME_INTERVALS_DEFAULT_VALUES },
         tornadoIntervals: {
             depositConfirmations: DEFAULT_TORNADO_CONFIRMATION,

--- a/packages/background/src/utils/constants/networks.ts
+++ b/packages/background/src/utils/constants/networks.ts
@@ -503,7 +503,7 @@ export const INITIAL_NETWORKS: Networks = {
         networkVersion: '97',
         nativeCurrency: {
             name: 'BNB Chain Native Token',
-            symbol: 'BNB',
+            symbol: 'tBNB',
             decimals: 18,
         },
         isCustomNetwork: false,
@@ -516,7 +516,7 @@ export const INITIAL_NETWORKS: Networks = {
         features: [FEATURES.SENDS],
         ens: false,
         showGasLevels: true,
-        rpcUrls: ['https://data-seed-prebsc-1-s1.binance.org:8545/'],
+        rpcUrls: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
         blockExplorerUrls: ['https://testnet.bscscan.io'],
         blockExplorerName: 'Bscscan',
         actionsTimeIntervals: { ...TESTNET_TIME_INTERVALS_DEFAULT_VALUES },

--- a/packages/background/yarn.lock
+++ b/packages/background/yarn.lock
@@ -203,9 +203,9 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
-"@block-wallet/chains-assets@https://github.com/block-wallet/chains-assets#v0.0.14":
-  version "0.0.13"
-  resolved "https://github.com/block-wallet/chains-assets#b062d08ead2c181f357db83802e7abcfd4e185b0"
+"@block-wallet/chains-assets@https://github.com/block-wallet/chains-assets#v0.0.17":
+  version "0.0.17"
+  resolved "https://github.com/block-wallet/chains-assets#9579190a32f6f91bd817f6215d6a6e33384e4b6a"
 
 "@block-wallet/circomlib@^0.0.21":
   version "0.0.21"

--- a/packages/ui/src/routes/networks/NetworkFormPage.tsx
+++ b/packages/ui/src/routes/networks/NetworkFormPage.tsx
@@ -133,7 +133,8 @@ const NetworkFormPage = ({
             }
             return RPCUrlValidation.EMPTY
         })
-
+    const [isNativelySupported, setIsNativelySupported] =
+        useState<boolean>(false)
     const { availableNetworks } = useBlankState()!
 
     const {
@@ -251,7 +252,14 @@ const NetworkFormPage = ({
                 : addNetwork(networkData)
         )
     })
-
+    useEffect(() => {
+        const existingNetwork = Object.values(availableNetworks).find(
+            (network) => network.chainId === Number(watchChainId)
+        )
+        setIsNativelySupported(
+            existingNetwork ? existingNetwork.nativelySupported : false
+        )
+    }, [watchChainId])
     const deleteNetwork = () => {
         removeNetworkInvoke.run(removeNetwork(network!.chainId!))
     }
@@ -348,7 +356,7 @@ const NetworkFormPage = ({
                 ) : null
             }
         >
-            {!network?.nativelySupported && (
+            {!isNativelySupported && (
                 <CollapsableWarning
                     dialog={{
                         title: "Warning",


### PR DESCRIPTION
# Name of the feature/issue

Multiple fixes related to node validation

## Description
- Fix the ending slash in the BSC testnet RPC URL (and its token) because the validation used to fail (it checks from here https://github.com/block-wallet/chains-assets/blob/main/dist/chain-list.js)
  - Add migration for the BSC testnet

![image](https://user-images.githubusercontent.com/98833290/195396920-e302b907-7f1b-44c8-9174-8ebbbf508776.png)

- Bump **chains-assets** to the version 0.0.17 to fix some networks RPC urls: zkSync testnet, Fantom Opera and Goerli. PRs: https://github.com/block-wallet/chains-assets/pull/56/files and https://github.com/block-wallet/chains-assets/pull/58/files


![image](https://user-images.githubusercontent.com/98833290/195396857-24d27661-bf32-49bb-8941-ebbac6d3351a.png)
![image](https://user-images.githubusercontent.com/98833290/195397194-59fe3d7c-ef8b-4d25-9d01-f0bc5646cfc2.png)
![image](https://user-images.githubusercontent.com/98833290/195398029-2c7ebec1-036d-4a55-8439-87140556de31.png)


- Fix warning message when adding/updating a network: it will show the warning the the network isn't natively supported  

![image](https://user-images.githubusercontent.com/98833290/195397278-4970fc5e-b989-4725-8a49-f99446d17507.png)
![image](https://user-images.githubusercontent.com/98833290/195397552-102da0f4-846b-4979-a6e9-ce9ff188f0d6.png)


## Type of change

Click the correct/s option/s

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update
