### PR TITLE
[Core] Incompatible sites

### DIFF
--- a/packages/provider/src/utils/constants/incompatibleSites.ts
+++ b/packages/provider/src/utils/constants/incompatibleSites.ts
@@ -1,6 +1,6 @@
 /**
  * List of sites that are not compatible with block wallet.
- *
+ * If a site is listed here, isBlockWallet flag will be set to false when injecting the provider and isMetamask will be true.
  * Make sure to add the domain name
  */
 export const incompatibleSites = [
@@ -34,4 +34,6 @@ export const incompatibleSites = [
     'yearn.finance',
     'zed.run',
     'zk.money',
+    'manifold.xyz',
+    'orionprotocol.io'
 ];


### PR DESCRIPTION
# Name of the feature/issue
Incompatible sites
## Description
This PR adds orionprotocol.io and manifold.xyz domains to our list of incompatible sites as they don't detect BlockWallet by default on their dApps.
## Type of change

Click the correct/s option/s

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update
