### PR TITLE
docs: remove type of change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
 # Name of the feature/issue
 
 ## Description
-
-## Type of change
-
-Click the correct/s option/s
-
-- [ ]  Bug fix (non-breaking change which fixes an issue)
-- [ ]  New feature (non-breaking change which adds functionality)
-- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ]  This change requires a documentation update


### PR DESCRIPTION
# Name of the feature/issue

Remove "type of change"

## Description

We want to replace "type of change" with the PR labels
