### PR TITLE
CI pipeline restrictions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,17 @@
 name: CI
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - '**.css'
+      - '**.json'
+      - '**.html'
+      - '**.nvmrc'
 
 env:
   BLOCK_WALLET_URL: url.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'dependabot/') == false
     steps:
       - name: Checkout monorepo
         uses: actions/checkout@v3

--- a/.github/workflows/skip_e2e.yml
+++ b/.github/workflows/skip_e2e.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**.js'
+      - '**.ts'
+      - '**.tsx'
+      - '**.css'
+      - '**.json'
+      - '**.html'
+      - '**.nvmrc'
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      # Fake job to skip the required status checks on the PR
+      - name: Skip e2e
+        run: |
+          echo "No e2e required"


### PR DESCRIPTION
# Name of the feature/issue

CI pipeline restrictions

## Description

- Run the CI pipeline (lint, test, build and e2e) only when:
  - There's an open PR with master as a target branch
  - Some files were modified (.js, .ts, etc)
  - Add "fake" e2e : If a workflow is skipped due to [path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging. For more information, see "[Handling skipped but required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks)."