### PR TITLE
[Fix] Use imperative go back routes to avoid crash networks flow

### DIFF
--- a/packages/ui/src/components/input/NetworkSelect.tsx
+++ b/packages/ui/src/components/input/NetworkSelect.tsx
@@ -172,7 +172,12 @@ const NetworkSelect: FunctionComponent<{
                     >
                         <ClickableText
                             className={`cursor-pointer flex flex-row justify-between pl-2 pr-2 pt-1 pb-1 leading-loose items-center w-full rounded-none`}
-                            onClick={() => history.push("/settings/networks")}
+                            onClick={() =>
+                                history.push({
+                                    pathname: "/settings/networks",
+                                    state: { isFromHomePage: true },
+                                })
+                            }
                         >
                             Edit Networks
                         </ClickableText>

--- a/packages/ui/src/routes/networks/NetworkFormPage.tsx
+++ b/packages/ui/src/routes/networks/NetworkFormPage.tsx
@@ -418,7 +418,7 @@ const NetworkFormPage = ({
                     if (addNetworkInvoke.isError) {
                         return addNetworkInvoke.reset()
                     }
-                    history.push("/settings/networks")
+                    history.replace("/settings/networks")
                 }}
             />
             <WaitingDialog

--- a/packages/ui/src/routes/networks/NetworksPage.tsx
+++ b/packages/ui/src/routes/networks/NetworksPage.tsx
@@ -55,6 +55,7 @@ const NetworkDisplay = ({
 const NetworksPage = () => {
     const { availableNetworks } = useBlankState()!
     const history = useOnMountHistory()
+    const isFromHomePage = history.location.state?.isFromHomePage ?? false
     const parsedNetworks = Object.values(availableNetworks)
         .sort(sortNetworksByOrder)
         .reduce(
@@ -97,7 +98,16 @@ const NetworksPage = () => {
         })
     }
     return (
-        <PopupLayout header={<PopupHeader title="Networks" />}>
+        <PopupLayout
+            header={
+                <PopupHeader
+                    title="Networks"
+                    onBack={() =>
+                        history.push(isFromHomePage ? "/" : "/settings")
+                    }
+                />
+            }
+        >
             <div className="flex flex-col p-6 space-y-6 w-full">
                 <ActionButton
                     icon={plusIcon}


### PR DESCRIPTION
# Name of the feature/issue
Extension breaks when new network is added and pressed in the goBack arrow.

## Description
The network flow broke after removing the imperative go back function to the settings page from the networks page. its a really complicated flow to be handled that way as it can be reached from different parts of the application like:
 - After adding/editing/removing a network
 - Going back from the Search networks page
 - From the home page
 - From the settings page.


