### PR TITLE
Allowing wasm execution on the last chrome version

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,20 +1,12 @@
 {
     "author": "BlockWallet",
     "background": {
-        "scripts": [
-            "hot-reload.js",
-            "background.js"
-        ]
+        "scripts": ["hot-reload.js", "background.js"]
     },
     "content_scripts": [
         {
-            "js": [
-                "content.js"
-            ],
-            "matches": [
-                "http://*/*",
-                "https://*/*"
-            ],
+            "js": ["content.js"],
+            "matches": ["http://*/*", "https://*/*"],
             "exclude_matches": [
                 "https://block-wallet.github.io/eth-ledger-bridge-keyring/*",
                 "https://connect.trezor.io/*"
@@ -23,12 +15,8 @@
             "all_frames": true
         },
         {
-            "js": [
-                "vendor/trezor/trezor-content.js"
-            ],
-            "matches": [
-                "*://connect.trezor.io/*/popup.html"
-            ]
+            "js": ["vendor/trezor/trezor-content.js"],
+            "matches": ["*://connect.trezor.io/*/popup.html"]
         }
     ],
     "browser_action": {
@@ -42,7 +30,7 @@
         "48": "icons/icon-48.png",
         "128": "icons/icon-128.png"
     },
-    "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
+    "content_security_policy": "script-src 'self' 'wasm-unsafe-eval' 'sha256-Y7AeZ5iPk2VXy19qgTiPos4J4VZjpkkU0cxXNs4yLlY='; object-src 'self'",
     "manifest_version": 2,
     "name": "BlockWallet",
     "permissions": [


### PR DESCRIPTION
# WASM execution

## Description

This PR aims to fix an issue in the current manifest related to the wasm files.

Once we upgrade our manifest to V3 this won't be an issue anymore because we won't need any wasm files.