### PR TITLE
fix: lock timeout

### DIFF
--- a/packages/background/src/controllers/BlankController.ts
+++ b/packages/background/src/controllers/BlankController.ts
@@ -450,7 +450,7 @@ export default class BlankController extends EventEmitter {
 
         this.UIStore = new ComposedStore<BlankAppUIState>({
             NetworkController: this.networkController.store,
-            AppStateController: this.appStateController.UIStore,
+            AppStateController: this.appStateController.store,
             OnboardingController: this.onboardingController.store,
             KeyringController: this.keyringController.memStore,
             AccountTrackerController: this.accountTrackerController.store,
@@ -512,7 +512,7 @@ export default class BlankController extends EventEmitter {
 
         // Check if app is unlocked
         const isAppUnlocked =
-            this.appStateController.UIStore.getState().isAppUnlocked;
+            this.appStateController.store.getState().isAppUnlocked;
 
         this.blockUpdatesController.setActiveSubscriptions(
             isAppUnlocked,

--- a/packages/background/src/controllers/BlankProviderController.ts
+++ b/packages/background/src/controllers/BlankProviderController.ts
@@ -36,7 +36,7 @@ import {
 } from '@block-wallet/provider/types';
 import { isEmpty } from 'lodash';
 import AppStateController, {
-    AppStateControllerMemState,
+    AppStateControllerState,
 } from './AppStateController';
 import NetworkController, {
     NetworkControllerState,
@@ -187,7 +187,7 @@ export default class BlankProviderController extends BaseController<BlankProvide
             this._stateWatcher.TRANSACTIONS
         );
 
-        this._appStateController.UIStore.subscribe(this._stateWatcher.LOCK);
+        this._appStateController.store.subscribe(this._stateWatcher.LOCK);
 
         this._permissionsController.store.subscribe(
             this._stateWatcher.PERMISSIONS
@@ -664,7 +664,7 @@ export default class BlankProviderController extends BaseController<BlankProvide
      */
     private _accountsRequest = (portId: string, emitUpdate = false) => {
         // Return empty array if app is locked
-        if (!this._appStateController.UIStore.getState().isAppUnlocked) {
+        if (!this._appStateController.store.getState().isAppUnlocked) {
             return [];
         }
 
@@ -1395,7 +1395,7 @@ export default class BlankProviderController extends BaseController<BlankProvide
                 this._checkWindows();
             }
         },
-        LOCK: (appState: AppStateControllerMemState) => {
+        LOCK: (appState: AppStateControllerState) => {
             // Resolve unlock handlers if app is unlocked
             if (
                 appState.isAppUnlocked === true &&
@@ -1515,7 +1515,7 @@ export default class BlankProviderController extends BaseController<BlankProvide
      */
     private _waitForUnlock = (): Promise<boolean> => {
         return new Promise((resolve, reject) => {
-            if (this._appStateController.UIStore.getState().isAppUnlocked) {
+            if (this._appStateController.store.getState().isAppUnlocked) {
                 return resolve(true);
             }
 

--- a/packages/background/src/utils/constants/initialState.ts
+++ b/packages/background/src/utils/constants/initialState.ts
@@ -6,10 +6,7 @@ import { ValuesOf } from '../types/helpers';
 import { IObservableStore } from '../../infrastructure/stores/ObservableStore';
 
 import { AccountTrackerState } from '../../controllers/AccountTrackerController';
-import {
-    AppStateControllerMemState,
-    AppStateControllerState,
-} from '../../controllers/AppStateController';
+import { AppStateControllerState } from '../../controllers/AppStateController';
 import { OnboardingControllerState } from '../../controllers/OnboardingController';
 import { PreferencesControllerState } from '../../controllers/PreferencesController';
 import type {
@@ -68,7 +65,7 @@ export type BlankAppState = {
 
 export type BlankAppUIState = {
     AccountTrackerController: AccountTrackerState;
-    AppStateController: AppStateControllerMemState;
+    AppStateController: AppStateControllerState;
     KeyringController: KeyringControllerMemState;
     OnboardingController: OnboardingControllerState;
     PreferencesController: PreferencesControllerState;
@@ -113,6 +110,9 @@ const initialState: BlankAppState = {
     },
     AppStateController: {
         idleTimeout: 5,
+        isAppUnlocked: false,
+        lastActiveTime: 0,
+        lockedByTimeout: false,
     },
     BlockUpdatesController: { blockData: {} },
     KeyringController: {

--- a/packages/background/src/utils/types/ethereum.ts
+++ b/packages/background/src/utils/types/ethereum.ts
@@ -1,4 +1,4 @@
-import { AppStateControllerMemState } from '@block-wallet/background/controllers/AppStateController';
+import { AppStateControllerState } from '@block-wallet/background/controllers/AppStateController';
 import { BlankProviderControllerState } from '@block-wallet/background/controllers/BlankProviderController';
 import { PermissionsControllerState } from '@block-wallet/background/controllers/PermissionsController';
 import { TransactionVolatileControllerState } from '@block-wallet/background/controllers/transactions/TransactionController';
@@ -27,7 +27,7 @@ export enum WindowRequest {
 
 export interface WindowRequestArguments {
     [WindowRequest.DAPP]: BlankProviderControllerState;
-    [WindowRequest.LOCK]: AppStateControllerMemState;
+    [WindowRequest.LOCK]: AppStateControllerState;
     [WindowRequest.PERMISSIONS]: PermissionsControllerState;
     [WindowRequest.TRANSACTIONS]: TransactionVolatileControllerState;
 }

--- a/packages/background/test/controllers/AppStateController.test.ts
+++ b/packages/background/test/controllers/AppStateController.test.ts
@@ -66,6 +66,9 @@ describe('AppState Controller', function () {
         appStateController = new AppStateController(
             {
                 idleTimeout: defaultIdleTimeout,
+                isAppUnlocked: true,
+                lastActiveTime: 0,
+                lockedByTimeout: false,
             },
             mockKeyringController,
             new TransactionController(
@@ -97,28 +100,27 @@ describe('AppState Controller', function () {
     });
 
     it('should update the last user active time', async function () {
-        const initialTime =
-            appStateController.UIStore.getState().lastActiveTime;
+        const initialTime = appStateController.store.getState().lastActiveTime;
         expect(initialTime).to.be.greaterThan(0);
         appStateController.setLastActiveTime();
         expect(
-            appStateController.UIStore.getState().lastActiveTime
+            appStateController.store.getState().lastActiveTime
         ).to.be.greaterThan(initialTime);
     });
 
     it('should lock and unlock properly', async function () {
         await mockKeyringController.createNewVaultAndKeychain('testPassword');
         await appStateController.lock();
-        expect(appStateController.UIStore.getState().isAppUnlocked).to.be.false;
+        expect(appStateController.store.getState().isAppUnlocked).to.be.false;
 
         await appStateController.unlock('testPassword');
-        expect(appStateController.UIStore.getState().isAppUnlocked).to.be.true;
+        expect(appStateController.store.getState().isAppUnlocked).to.be.true;
 
         await appStateController.lock();
-        expect(appStateController.UIStore.getState().isAppUnlocked).to.be.false;
+        expect(appStateController.store.getState().isAppUnlocked).to.be.false;
 
         await appStateController.unlock('testPassword');
-        expect(appStateController.UIStore.getState().isAppUnlocked).to.be.true;
+        expect(appStateController.store.getState().isAppUnlocked).to.be.true;
     });
 
     it('should set a custom auto block timeout', async function () {
@@ -135,11 +137,11 @@ describe('AppState Controller', function () {
         // Set idle timeout to 600 ms
         appStateController.setIdleTimeout(0.01);
 
-        expect(appStateController.UIStore.getState().isAppUnlocked).to.be.true;
+        expect(appStateController.store.getState().isAppUnlocked).to.be.true;
 
         window.setTimeout(function () {
             expect(
-                appStateController.UIStore.getState().isAppUnlocked
+                appStateController.store.getState().isAppUnlocked
             ).to.be.false;
             done();
         }, 700);

--- a/packages/background/test/controllers/BlankProviderController.test.ts
+++ b/packages/background/test/controllers/BlankProviderController.test.ts
@@ -187,6 +187,9 @@ describe('Blank Provider Controller', function () {
         appStateController = new AppStateController(
             {
                 idleTimeout: defaultIdleTimeout,
+                isAppUnlocked: true,
+                lastActiveTime: 0,
+                lockedByTimeout: false,
             },
             mockKeyringController,
             transactionController,

--- a/packages/background/test/infrastructure/stores/migrator/reconciler.test.ts
+++ b/packages/background/test/infrastructure/stores/migrator/reconciler.test.ts
@@ -43,6 +43,9 @@ const persistedState = {
     },
     AppStateController: {
         idleTimeout: 5,
+        isAppUnlocked: true,
+        lastActiveTime: 0,
+        lockedByTimeout: false,
     },
     BlankDepositController: {
         pendingWithdrawals: {
@@ -165,6 +168,9 @@ const initialState: BlankAppState & {
     },
     AppStateController: {
         idleTimeout: 5,
+        isAppUnlocked: true,
+        lastActiveTime: 0,
+        lockedByTimeout: false,
     },
     KeyringController: {
         isUnlocked: false,
@@ -308,6 +314,9 @@ describe('State reconciler', () => {
             },
             AppStateController: {
                 idleTimeout: 5,
+                isAppUnlocked: true,
+                lastActiveTime: 0,
+                lockedByTimeout: false,
             },
             BlankDepositController: {
                 pendingWithdrawals: {

--- a/packages/background/webpack/webpack.shared.js
+++ b/packages/background/webpack/webpack.shared.js
@@ -2,8 +2,10 @@ const path = require('path');
 const webpack = require('webpack');
 const Dotenv = require('dotenv-webpack');
 const ESLintWebpackPlugin = require('eslint-webpack-plugin');
+/*
 const BundleAnalyzerPlugin =
     require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+*/
 
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
@@ -34,10 +36,12 @@ const plugins = [
         extensions: ['ts'],
         eslintPath: require.resolve('eslint'),
     }),
+    /*
     new BundleAnalyzerPlugin({
         analyzerMode: 'static',
         reportFilename: '../packages/background/bundle_size_report.html',
     }),
+    */
     new webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
     }),

--- a/packages/ui/src/mock/MockBackgroundState.tsx
+++ b/packages/ui/src/mock/MockBackgroundState.tsx
@@ -12,6 +12,7 @@ import { AccountStatus, AccountType } from "../context/commTypes"
 
 export const initBackgroundState: BackgroundStateType = {
     blankState: {
+        idleTimeout: 0,
         antiPhishingImage: "",
         userTokens: {},
         deletedUserTokens: {},


### PR DESCRIPTION
# Lock timeout on mv3

## Description

As the service worker restarts all the time, all the non-storage-state objects get lost in every single restart. The app auto lock is handled by a timeout object which is created again in every restart, so the app never auto blocks because the countdown was restarted all the time. What we do is to check if the app should be locked when the controller is created again so when a restart occurs.