### PR TITLE
[Feat] TokenDisplay show balance

### DIFF
--- a/packages/ui/src/components/assets/AssetSelection.tsx
+++ b/packages/ui/src/components/assets/AssetSelection.tsx
@@ -293,13 +293,14 @@ export const AssetSelection: FC<AssetSelectionProps> = ({
                             onClick={() => onAssetClick(asset, setActive)}
                         >
                             <TokenDisplay
-                                data={{ ...asset }}
+                                data={{ ...asset.token }}
                                 clickable={false}
                                 active={
                                     selectedAsset?.token.address ===
                                     asset.token.address
                                 }
                                 hoverable={true}
+                                balance={asset.balance}
                             />
                         </div>
                     )

--- a/packages/ui/src/components/assets/AssetSelection.tsx
+++ b/packages/ui/src/components/assets/AssetSelection.tsx
@@ -293,9 +293,7 @@ export const AssetSelection: FC<AssetSelectionProps> = ({
                             onClick={() => onAssetClick(asset, setActive)}
                         >
                             <TokenDisplay
-                                data={{
-                                    ...asset.token,
-                                }}
+                                data={{ ...asset }}
                                 clickable={false}
                                 active={
                                     selectedAsset?.token.address ===

--- a/packages/ui/src/components/token/TokenDisplay.tsx
+++ b/packages/ui/src/components/token/TokenDisplay.tsx
@@ -1,11 +1,13 @@
 import TokenLogo from "./TokenLogo"
 import checkmarkMiniIcon from "../../assets/images/icons/checkmark_mini.svg"
 import classnames from "classnames"
-import { TokenResponse } from "../../routes/settings/AddTokensPage"
 import { useState, FunctionComponent } from "react"
+import { TokenWithBalance } from "../../context/hooks/useTokensList"
+import { formatUnits } from "ethers/lib/utils"
+import { formatRounded } from "../../util/formatRounded"
 
 type TokenDisplayType = {
-    data: TokenResponse
+    data: TokenWithBalance
     clickable?: boolean
     active?: boolean | false
     hoverable?: boolean | false
@@ -40,12 +42,28 @@ const TokenDisplay: FunctionComponent<TokenDisplayType> = ({
             )}
             onClick={() => (clickable ? setSelected(!selected) : null)}
         >
-            <TokenLogo bigLogo logo={data.logo} name={data.name} />
-            <p className={"text-sm text-black font-semibold ml-4 truncate"}>
-                {data.name}
+            <TokenLogo bigLogo logo={data.token.logo} name={data.token.name} />
+            <p className="ml-4 truncate">
+                <span className={"text-sm text-black font-semibold"}>
+                    {data.token.name}
+                </span>
+                <span
+                    className="text-xs text-gray-600"
+                    title={formatUnits(
+                        data.balance || "0",
+                        data.token.decimals
+                    )}
+                >
+                    <br />
+                    Balance:{" "}
+                    {formatRounded(
+                        formatUnits(data.balance || "0", data.token.decimals),
+                        6
+                    )}
+                </span>
             </p>
             <p className={"text-sm text-gray-400 ml-auto pl-1 pr-6"}>
-                {data.symbol}
+                {data.token.symbol}
             </p>
             <img
                 src={checkmarkMiniIcon}

--- a/packages/ui/src/components/token/TokenDisplay.tsx
+++ b/packages/ui/src/components/token/TokenDisplay.tsx
@@ -2,15 +2,17 @@ import TokenLogo from "./TokenLogo"
 import checkmarkMiniIcon from "../../assets/images/icons/checkmark_mini.svg"
 import classnames from "classnames"
 import { useState, FunctionComponent } from "react"
-import { TokenWithBalance } from "../../context/hooks/useTokensList"
 import { formatUnits } from "ethers/lib/utils"
 import { formatRounded } from "../../util/formatRounded"
+import { TokenResponse } from "../../routes/settings/AddTokensPage"
+import { BigNumber } from "ethers"
 
 type TokenDisplayType = {
-    data: TokenWithBalance
+    data: TokenResponse
     clickable?: boolean
     active?: boolean | false
     hoverable?: boolean | false
+    balance?: BigNumber | undefined
 }
 
 /**
@@ -23,12 +25,14 @@ type TokenDisplayType = {
  * @param clickable - Determines if you can click element to show selected style.
  * @param active - Determines if the element is already showing selected style.
  * @param hoverable - Determines if the element shows a hover style.
+ * @param balance - Contains the asset balance in case it exists. e.g. if it is a New Asset there is no balance
  */
 const TokenDisplay: FunctionComponent<TokenDisplayType> = ({
     data,
     clickable,
     active,
     hoverable,
+    balance,
 }) => {
     const [selected, setSelected] = useState<boolean>(active ? active : false)
 
@@ -42,28 +46,22 @@ const TokenDisplay: FunctionComponent<TokenDisplayType> = ({
             )}
             onClick={() => (clickable ? setSelected(!selected) : null)}
         >
-            <TokenLogo bigLogo logo={data.token.logo} name={data.token.name} />
-            <p className="ml-4 truncate">
+            <TokenLogo bigLogo logo={data.logo} name={data.name} />
+            <div className="flex flex-col ml-4 truncate">
                 <span className={"text-sm text-black font-semibold"}>
-                    {data.token.name}
+                    {data.name}
                 </span>
-                <span
-                    className="text-xs text-gray-600"
-                    title={formatUnits(
-                        data.balance || "0",
-                        data.token.decimals
-                    )}
-                >
-                    <br />
-                    Balance:{" "}
-                    {formatRounded(
-                        formatUnits(data.balance || "0", data.token.decimals),
-                        6
-                    )}
-                </span>
-            </p>
+                {balance && (
+                    <span
+                        className={"text-xs text-gray-600 mt-1"}
+                        title={formatUnits(balance, data.decimals)}
+                    >
+                        {formatRounded(formatUnits(balance, data.decimals), 6)}
+                    </span>
+                )}
+            </div>
             <p className={"text-sm text-gray-400 ml-auto pl-1 pr-6"}>
-                {data.token.symbol}
+                {data.symbol}
             </p>
             <img
                 src={checkmarkMiniIcon}


### PR DESCRIPTION
# Name of the feature/issue
TokenDisplay show balance

## Description
If it applies, prints the token balance when showing it. In case of new assets there is no balance so the parameter is not sent. 

![image](https://user-images.githubusercontent.com/106965328/197858847-5ab0852d-8c59-41f2-85c7-e6efbeb8ceba.png)
