### PR TITLE
[Fix] Transaction details for token transfers

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@block-wallet/background",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "private": true,
     "dependencies": {
         "@block-wallet/chains-assets": "https://github.com/block-wallet/chains-assets#v0.0.17",

--- a/packages/background/src/controllers/TransactionWatcherController.ts
+++ b/packages/background/src/controllers/TransactionWatcherController.ts
@@ -1341,7 +1341,7 @@ export class TransactionWatcherController extends BaseController<TransactionWatc
             confirmationTime: time,
             submittedTime: time,
             status:
-                parseInt(tx.isError) === 0
+                parseInt(tx.isError ?? 0) === 0
                     ? TransactionStatus.CONFIRMED
                     : TransactionStatus.FAILED,
             chainId: chainId,
@@ -1349,7 +1349,10 @@ export class TransactionWatcherController extends BaseController<TransactionWatc
             transactionParams: {
                 to: tx.to,
                 from: tx.from,
-                value: BigNumber.from(tx.value),
+                value:
+                    type === TransactionTypeEnum.Native
+                        ? BigNumber.from(tx.value)
+                        : BigNumber.from(0),
                 hash: tx.hash,
                 nonce: Number(tx.nonce),
                 data: tx.input,

--- a/packages/background/src/infrastructure/stores/migrator/migrations/index.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/index.ts
@@ -44,6 +44,7 @@ import migration42 from './migration-42';
 import migration43 from './migration-43';
 import migration44 from './migration-44';
 import migration45 from './migration-45';
+import migration46 from './migration-46';
 
 const migrations: IMigration[] = [
     migration01,
@@ -91,5 +92,6 @@ const migrations: IMigration[] = [
     migration43,
     migration44,
     migration45,
+    migration46,
 ];
 export default (): IMigration[] => migrations;

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-46.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-46.ts
@@ -1,0 +1,46 @@
+import { TransactionTypeEnum } from '../../../../controllers/TransactionWatcherController';
+import { BigNumber } from 'ethers';
+import { BlankAppState } from '../../../../utils/constants/initialState';
+import { IMigration } from '../IMigration';
+
+/**
+ * Fixes incoming transactions statuses and values
+ */
+export default {
+    migrate: async (persistedState: BlankAppState) => {
+        const transactionsByChain =
+            persistedState.TransactionWatcherControllerState.transactions;
+
+        for (const chainId in transactionsByChain) {
+            const transactionsByAccount = transactionsByChain[chainId] || {};
+            for (const account in transactionsByAccount) {
+                const transactionsByType = transactionsByAccount[account] || {};
+                for (const type in transactionsByType) {
+                    const transactions =
+                        transactionsByType[type as TransactionTypeEnum];
+                    if (
+                        type !== TransactionTypeEnum.Native &&
+                        transactions &&
+                        transactions.transactions
+                    ) {
+                        for (const hash in transactions.transactions) {
+                            const tx = transactions.transactions[hash];
+                            if (tx && tx.transactionParams) {
+                                tx.transactionParams.value = BigNumber.from(0);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return {
+            ...persistedState,
+            TransactionWatcherControllerState: {
+                ...persistedState.TransactionWatcherControllerState,
+                transactions: transactionsByChain,
+            },
+        };
+    },
+    version: '0.7.4',
+} as IMigration;

--- a/packages/ui/src/components/transactions/TransactionDetailsBasic.tsx
+++ b/packages/ui/src/components/transactions/TransactionDetailsBasic.tsx
@@ -24,6 +24,10 @@ import {
 } from "../../context/commTypes"
 import { calcExchangeRate } from "../../util/exchangeUtils"
 import isNil from "../../util/isNil"
+import { resolveTransactionTo } from "../../util/transactionUtils"
+import useCopyToClipboard, {
+    useMultipleCopyToClipboard,
+} from "../../util/hooks/useCopyToClipboard"
 
 const bnOr0 = (value: any = 0) => BigNumber.from(value)
 
@@ -34,6 +38,7 @@ export const TransactionDetails: FunctionComponent<
     const { nativeCurrency } = useSelectedNetwork()
     const accounts = useSortedAccounts()
     const addressBook = useAddressBook()
+    const { onCopy, copied } = useMultipleCopyToClipboard()
 
     const details = useMemo(() => {
         const isConfirmed = transaction.status === TransactionStatus.CONFIRMED
@@ -263,16 +268,8 @@ export const TransactionDetails: FunctionComponent<
         // eslint-disable-next-line
     }, [transaction, _nonce])
 
-    const [copied, setCopied] = useState(-1)
-
-    const copy = (value: string, i: number) => async () => {
-        await navigator.clipboard.writeText(value)
-        setCopied(i)
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        setCopied(-1)
-    }
-
-    const { from, to } = transaction.transactionParams
+    const { from } = transaction.transactionParams
+    const transactionTo = resolveTransactionTo(transaction)
 
     let fromName
     if (from) {
@@ -289,15 +286,16 @@ export const TransactionDetails: FunctionComponent<
     }
 
     let toName
-    if (to) {
+    if (transactionTo) {
         toName = accounts.find(
-            (account) => account.address.toLowerCase() === to.toLowerCase()
+            (account) =>
+                account.address.toLowerCase() === transactionTo.toLowerCase()
         )?.name
 
         //If to was not found in accounts, then we look into the address book.
         if (!toName) {
             toName = Object.values(addressBook).find(
-                (address) => address.address.toLowerCase() === to
+                (address) => address.address.toLowerCase() === transactionTo
             )?.name
         }
     }
@@ -312,26 +310,21 @@ export const TransactionDetails: FunctionComponent<
             <div className="flex flex-row items-center justify-between w-full py-4 relative">
                 <div
                     className="flex flex-row items-center w-1/2 justify-start group relative cursor-pointer"
-                    onClick={copy(transaction.transactionParams.from ?? "", 0)}
+                    onClick={() => onCopy(from ?? "", 0)}
                 >
                     <div>
                         <AccountIcon
                             className="h-6 w-6"
-                            fill={getAccountColor(
-                                transaction.transactionParams.from!
-                            )}
+                            fill={getAccountColor(from!)}
                         />
                     </div>
                     <span
-                        title={transaction.transactionParams.from}
+                        title={from}
                         className="pl-2 font-bold text-sm truncate"
                     >
                         {fromName
                             ? formatName(fromName, 12)
-                            : formatHash(
-                                  transaction.transactionParams.from!,
-                                  2
-                              )}
+                            : formatHash(from!, 2)}
                     </span>
                     <CopyTooltip copied={copied === 0} text="Copy address" />
                 </div>
@@ -349,28 +342,21 @@ export const TransactionDetails: FunctionComponent<
                 ></div>
                 <div
                     className="relative flex flex-row items-center cursor-pointer group w-1/2 pl-6"
-                    onClick={copy(
-                        transaction.transferType?.to ??
-                            transaction.transactionParams.to ??
-                            "",
-                        1
-                    )}
+                    onClick={() => onCopy(transactionTo, 1)}
                 >
                     <div>
                         <AccountIcon
                             className="h-6 w-6"
-                            fill={getAccountColor(
-                                transaction.transactionParams.to!
-                            )}
+                            fill={getAccountColor(transactionTo!)}
                         />
                     </div>
                     <span
-                        title={transaction.transactionParams.to}
+                        title={transactionTo}
                         className="pl-2 font-bold text-sm truncate"
                     >
                         {toName
                             ? formatName(toName, 12)
-                            : formatHash(transaction.transactionParams.to!, 2)}
+                            : formatHash(transactionTo!, 2)}
                     </span>
                     <CopyTooltip copied={copied === 1} text="Copy address" />
                 </div>

--- a/packages/ui/src/util/hooks/useCopyToClipboard.ts
+++ b/packages/ui/src/util/hooks/useCopyToClipboard.ts
@@ -14,4 +14,18 @@ const useCopyToClipboard = (initialText?: string) => {
     }
 }
 
+export const useMultipleCopyToClipboard = () => {
+    const [copied, setCopied] = useState<number>(-1)
+    return {
+        copied,
+        //you can override the inital text if you want to.
+        onCopy: async (text: string, id: number) => {
+            await navigator.clipboard.writeText(text || "")
+            setCopied(id)
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+            setCopied(-1)
+        },
+    }
+}
+
 export default useCopyToClipboard

--- a/packages/ui/src/util/transactionUtils.ts
+++ b/packages/ui/src/util/transactionUtils.ts
@@ -3,7 +3,7 @@ import {
     TransactionMeta,
     uiTransactionParams,
 } from "@block-wallet/background/controllers/transactions/utils/types"
-import { TransactionStatus } from "../context/commTypes"
+import { TransactionCategories, TransactionStatus } from "../context/commTypes"
 import { BigNumber } from "ethers"
 import { DappRequestSigningStatus } from "../context/hooks/useDappRequest"
 export interface RichedTransactionMeta extends TransactionMeta {
@@ -114,4 +114,14 @@ export const canUserSubmitTransaction = (
     status: TransactionStatus
 ): boolean => {
     return [TransactionStatus.UNAPPROVED].includes(status)
+}
+
+export const resolveTransactionTo = (tx: TransactionMeta): string => {
+    let to: string | undefined
+    if (
+        tx.transactionCategory === TransactionCategories.TOKEN_METHOD_TRANSFER
+    ) {
+        to = tx.transferType?.to
+    }
+    return to ?? tx.transactionParams.to ?? ""
 }


### PR DESCRIPTION
# Name of the feature/issue
Fix some issues related to the transaction details for the token transfer transactions

## Description
When opening a transaction details of a token transfer transaction:
- The `transactionTo` is not 100% accurate since we are putting the contract address and not the destination address of the transfer.
- The incoming transactions are parsing the tx fees as the value of the transaction, making the dialog to behave in a weird way. 