### PR TITLE
fix: added normalize networks order to new migration.

### DIFF
--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
@@ -86,7 +86,6 @@ export default {
             order: 10,
         };
 
-
         const orderedNetworks = normalizeNetworksOrder(updatedNetworks);
 
         return {

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
@@ -6,6 +6,7 @@ import {
     DEFAULT_TORNADO_CONFIRMATION,
     DERIVATIONS_FORWARD,
 } from '../../../../controllers/blank-deposit/types';
+import { normalizeNetworksOrder } from '@block-wallet/background/utils/networks';
 
 /**
  * This migration adds the zkSync alpha testnet network to the networks
@@ -84,11 +85,15 @@ export default {
             ...updatedNetworks.LOCALHOST,
             order: 10,
         };
+
+
+        const orderedNetworks = normalizeNetworksOrder(updatedNetworks);
+
         return {
             ...persistedState,
             NetworkController: {
                 ...persistedState.NetworkController,
-                availableNetworks: { ...updatedNetworks },
+                availableNetworks: { ...orderedNetworks },
             },
         };
     },

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
@@ -6,7 +6,7 @@ import {
     DEFAULT_TORNADO_CONFIRMATION,
     DERIVATIONS_FORWARD,
 } from '../../../../controllers/blank-deposit/types';
-import { normalizeNetworksOrder } from '@block-wallet/background/utils/networks';
+import { normalizeNetworksOrder } from '../../../../utils/networks';
 
 /**
  * This migration adds the zkSync alpha testnet network to the networks


### PR DESCRIPTION
# Name of the feature/issue
Normalize networks order
## Description
added normalize networks order method to new migration to prevent gaps and incorrect orders.