### PR TITLE
[Chore] UI sourcemaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build/prod:
 	@rm -Rf dist/
 	@$(MAKE) ENVIRONMENT=prod build/background --no-print-directory
 	@$(MAKE) ENVIRONMENT=prod build/provider --no-print-directory
-	@$(MAKE) build/ui --no-print-directory
+	@$(MAKE) GENERATE_SOURCEMAP=false build/ui --no-print-directory
 	@$(MAKE) cp/snarks --no-print-directory
 	@$(MAKE) cp/release-notes --no-print-directory
 


### PR DESCRIPTION
# Name of the feature/issue
UI Sourcemaps in Production mode
## Description

This PR adds the `GENERATE_SOURCEMAP=false` flag in UI's production build script. These sourcemaps are not needed in prod and removing them makes the extension zipped 4MB smaller.
<img width="505" alt="image" src="https://user-images.githubusercontent.com/11839151/200633828-c5e5130b-b900-4ba7-afd1-25c72fdd665f.png">

<img width="683" alt="image" src="https://user-images.githubusercontent.com/11839151/200634260-6e265e0d-f550-4252-ab3b-e151fb9f2a69.png">


