### PR TITLE
[Fix] Release notes typo

### DIFF
--- a/release-notes.json
+++ b/release-notes.json
@@ -316,7 +316,7 @@
                     "notes": [
                         {
                             "type": "success",
-                            "message": "Added support for Sroll L1 and L2 Testnets."
+                            "message": "Added support for Scroll L1 and L2 Testnets."
                         },
                         {
                             "type": "success",


### PR DESCRIPTION
# Name of the feature/issue
Release Notes typo
## Description
Fixed release-notes typo. It was corrected manually before the release, this is just to replicate the fix in the repo.