### PR TITLE
[Fix] SeedImport OnPaste vs OnChange

### DIFF
--- a/packages/ui/src/components/setup/SeedImport.tsx
+++ b/packages/ui/src/components/setup/SeedImport.tsx
@@ -212,8 +212,6 @@ const SeedImport: FunctionComponent<{
                                             if (newSP.trim().match(/\s/u)) {
                                                 e.preventDefault()
                                                 onSeedPhrasePaste(newSP)
-                                            } else {
-                                                onSeedPhraseWordChange(i, newSP)
                                             }
                                         }}
                                     />


### PR DESCRIPTION
# Name of the feature/issue
SeedImport OnPaste vs OnChange

## Description
OnPaste runs logic for seedPhrase with several words. If you paste only one word or you write one word it will run OnChange. If onPaste runs for one word it duplicates the line