### PR TITLE
[Fix] Restore network indicator in the PopupHeader

### DIFF
--- a/packages/ui/src/components/popup/PopupHeader.tsx
+++ b/packages/ui/src/components/popup/PopupHeader.tsx
@@ -127,8 +127,8 @@ const PopupHeader: FunctionComponent<PopupHeaderProps> = ({
             >
                 {title}
             </span>
-            {actions && (
-                <div className="ml-auto">
+            <div className="ml-auto flex space-x-1">
+                {actions && (
                     <Dropdown>
                         <Dropdown.Menu id="popup-actions">
                             {actions.map((action, idx) => {
@@ -140,27 +140,31 @@ const PopupHeader: FunctionComponent<PopupHeaderProps> = ({
                             })}
                         </Dropdown.Menu>
                     </Dropdown>
-                </div>
-            )}
+                )}
+                {networkIndicator && (
+                    <NetworkDisplayBadge truncate network={network} />
+                )}
+                {close && (
+                    <button
+                        onClick={(e) => {
+                            if (onClose) return onClose(e)
+                            history.push(
+                                typeof close === "string" ? close : "/home"
+                            )
+                        }}
+                        disabled={disabled}
+                        className={classnames(
+                            "p-2 -mr-2 transition duration-300 rounded-full hover:bg-primary-100 hover:text-primary-300",
+                            disabled && "pointer-events-none text-gray-300"
+                        )}
+                        type="button"
+                    >
+                        <CloseIcon />
+                    </button>
+                )}
+            </div>
+
             {children}
-            {close && (
-                <button
-                    onClick={(e) => {
-                        if (onClose) return onClose(e)
-                        history.push(
-                            typeof close === "string" ? close : "/home"
-                        )
-                    }}
-                    disabled={disabled}
-                    className={classnames(
-                        "p-2 ml-auto -mr-2 transition duration-300 rounded-full hover:bg-primary-100 hover:text-primary-300",
-                        disabled && "pointer-events-none text-gray-300"
-                    )}
-                    type="button"
-                >
-                    <CloseIcon />
-                </button>
-            )}
         </div>
     )
 }

--- a/packages/ui/src/routes/bridge/BridgeConfirmPage.tsx
+++ b/packages/ui/src/routes/bridge/BridgeConfirmPage.tsx
@@ -5,7 +5,6 @@ import GasPriceComponent from "../../components/transactions/GasPriceComponent"
 import HardwareDeviceNotLinkedDialog from "../../components/dialog/HardwareDeviceNotLinkedDialog"
 import LoadingDialog from "../../components/dialog/LoadingDialog"
 import NetworkDisplay from "../../components/network/NetworkDisplay"
-import NetworkDisplayBadge from "../../components/chain/NetworkDisplayBadge"
 import PopupFooter from "../../components/popup/PopupFooter"
 import PopupHeader from "../../components/popup/PopupHeader"
 import PopupLayout from "../../components/popup/PopupLayout"
@@ -470,6 +469,7 @@ const BridgeConfirmPage: FunctionComponent<{}> = () => {
                 <PopupHeader
                     title="Bridge"
                     close="/"
+                    networkIndicator
                     onBack={() => {
                         // Avoid returning to the approve page.
                         history.push({
@@ -478,11 +478,7 @@ const BridgeConfirmPage: FunctionComponent<{}> = () => {
                         })
                     }}
                     disabled={isBridging}
-                >
-                    <div className="flex grow justify-end pr-1">
-                        <NetworkDisplayBadge network={networkLabel} truncate />
-                    </div>
-                </PopupHeader>
+                />
             }
             footer={
                 <PopupFooter>

--- a/packages/ui/src/routes/bridge/BridgeSetupPage.tsx
+++ b/packages/ui/src/routes/bridge/BridgeSetupPage.tsx
@@ -1,6 +1,5 @@
 import AssetAmountDisplay from "../../components/assets/AssetAmountDisplay"
 import ErrorMessage from "../../components/error/ErrorMessage"
-import NetworkDisplayBadge from "../../components/chain/NetworkDisplayBadge"
 import PopupFooter from "../../components/popup/PopupFooter"
 import PopupHeader from "../../components/popup/PopupHeader"
 import PopupLayout from "../../components/popup/PopupLayout"
@@ -430,6 +429,7 @@ const BridgeSetupPage: FunctionComponent<{}> = () => {
                     title="Bridge"
                     close="/"
                     keepState
+                    networkIndicator
                     onBack={() =>
                         fromAssetPage
                             ? history.push({
@@ -440,14 +440,7 @@ const BridgeSetupPage: FunctionComponent<{}> = () => {
                               })
                             : history.push("/home")
                     }
-                >
-                    <div className="flex grow justify-end pr-1">
-                        <NetworkDisplayBadge
-                            network={currentNetwork}
-                            truncate
-                        />
-                    </div>
-                </PopupHeader>
+                />
             }
             footer={
                 <PopupFooter>

--- a/packages/ui/src/routes/transaction/ApprovePage.tsx
+++ b/packages/ui/src/routes/transaction/ApprovePage.tsx
@@ -55,7 +55,6 @@ import { SwapConfirmPageLocalState } from "../swap/SwapConfirmPage"
 import { ExchangeType } from "../../context/commTypes"
 import { TransactionAdvancedData } from "@block-wallet/background/controllers/transactions/utils/types"
 import { BridgeConfirmPageLocalState } from "../bridge/BridgeConfirmPage"
-import NetworkDisplayBadge from "../../components/chain/NetworkDisplayBadge"
 import { useBlankState } from "../../context/background/backgroundHooks"
 
 const UNLIMITED_ALLOWANCE = ethers.constants.MaxUint256
@@ -754,12 +753,9 @@ const ApprovePage: FunctionComponent<{}> = () => {
                     title={"Allowance"}
                     disabled={isApproving}
                     onBack={onBack()}
+                    networkIndicator
                     keepState
-                >
-                    <div className="flex grow justify-end pr-1">
-                        <NetworkDisplayBadge network={network} truncate />
-                    </div>
-                </PopupHeader>
+                />
             }
             footer={
                 <PopupFooter>


### PR DESCRIPTION
# Name of the feature/issue
Rollback the network indicator

## Description
When we merged the Bridging PR to master, the network indicator implementation in the PopupHeader was removed by mistake. This PR rollbacks that code and uses everywhere it was being rendered manually in the header.