### PR TITLE
[Fix] Non-clickable network change when provider down

### DIFF
--- a/packages/ui/src/components/input/NetworkSelect.tsx
+++ b/packages/ui/src/components/input/NetworkSelect.tsx
@@ -8,7 +8,6 @@ import { useBlankState } from "../../context/background/backgroundHooks"
 import classnames from "classnames"
 import { useOnClickOutside } from "../../util/useOnClickOutside"
 import { changeNetwork, setShowTestNetworks } from "../../context/commActions"
-import TransparentOverlay from "../loading/TransparentOverlay"
 import { Network } from "@block-wallet/background/utils/constants/networks"
 import classNames from "classnames"
 import { sortNetworksByOrder } from "../../util/networkUtils"
@@ -51,8 +50,6 @@ const NetworkSelect: FunctionComponent<{
         selectedNetwork,
         availableNetworks,
         showTestNetworks,
-        isNetworkChanging,
-        isRatesChangingAfterNetworkChange,
         isImportingDeposits,
         isUserNetworkOnline,
     } = useBlankState()!
@@ -76,9 +73,6 @@ const NetworkSelect: FunctionComponent<{
             role="menu"
             data-testid="network-selector"
         >
-            {(isNetworkChanging || isRatesChangingAfterNetworkChange) && (
-                <TransparentOverlay />
-            )}
             <div
                 onClick={() => {
                     if (!isImportingDeposits) {

--- a/packages/ui/src/components/loading/TransparentOverlay.tsx
+++ b/packages/ui/src/components/loading/TransparentOverlay.tsx
@@ -2,7 +2,7 @@
  * Transparent overlay component to prevent clicks on all the extension buttons while loading.
  */
 const TransparentOverlay = () => (
-    <div className="fixed inset-0 w-full h-screen z-50"></div>
+    <div className="fixed inset-0 w-full h-screen z-40"></div>
 )
 
 export default TransparentOverlay

--- a/packages/ui/src/routes/PopupPage.tsx
+++ b/packages/ui/src/routes/PopupPage.tsx
@@ -38,6 +38,7 @@ import { useTokensList } from "../context/hooks/useTokensList"
 import TokenSummary from "../components/token/TokenSummary"
 import GasPricesInfo from "../components/gas/GasPricesInfo"
 import DoubleArrowHoverAnimation from "../components/icons/DoubleArrowHoverAnimation"
+import TransparentOverlay from "../components/loading/TransparentOverlay"
 
 const AccountDisplay = () => {
     const blankState = useBlankState()!
@@ -165,6 +166,7 @@ const PopupPage = () => {
                 }}
                 onDone={() => setHasErrorDialog(false)}
             />
+            {isLoading && <TransparentOverlay />}
             <div
                 className="absolute top-0 left-0 z-10 flex flex-col items-start w-full p-6 bg-white bg-opacity-75 border-b border-b-gray-200 popup-layout"
                 style={{ backdropFilter: "blur(4px)" }}


### PR DESCRIPTION
# Name of the feature/issue
Non-clickable network change when the provider is down
## Description
The network select was non-clickable from the provider down dialog due to the loading transparent overlay.