### PR TITLE
[Fix] Enable submit button on Seed Import/New account

### DIFF
--- a/packages/ui/src/components/setup/SeedImport.tsx
+++ b/packages/ui/src/components/setup/SeedImport.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useCallback, useState } from "react"
+import { FunctionComponent, useCallback, useEffect, useState } from "react"
 import { Classes, classnames } from "../../styles"
 import LinkButton from "../button/LinkButton"
 import Divider from "../Divider"
@@ -54,6 +54,7 @@ const SeedImport: FunctionComponent<{
     )
     const [seedPhraseError, setSeedPhraseError] = useState("")
     const [isLoading, setIsLoading] = useState(false)
+    const [isImportDisabled, setIsImportDisabled] = useState(true)
     const {
         register,
         handleSubmit,
@@ -109,7 +110,6 @@ const SeedImport: FunctionComponent<{
                     setSeedPhraseError("")
                 }
             }
-
             setSeedPhrase(newSP)
         },
         [setSeedPhrase, setSeedPhraseError]
@@ -152,6 +152,24 @@ const SeedImport: FunctionComponent<{
         },
         [numberOfWords, onSeedPhraseChange]
     )
+
+    const passwordValues = watch()
+    useEffect(() => {
+        if (
+            seedPhrase &&
+            !seedPhraseError &&
+            !errors.password &&
+            seedPhrase.filter((s) => s !== "").length === numberOfWords &&
+            passwordValues.password &&
+            passwordValues.passwordConfirmation &&
+            passwordValues.password === passwordValues.passwordConfirmation &&
+            passwordValues.acceptTOU
+        ) {
+            setIsImportDisabled(false)
+        } else {
+            setIsImportDisabled(true)
+        }
+    }, [seedPhrase, passwordValues, seedPhraseError, errors.password])
 
     return (
         <form
@@ -284,21 +302,10 @@ const SeedImport: FunctionComponent<{
                     className={classnames(
                         Classes.button,
                         "w-1/2 font-bold border-2 border-primary-300",
-                        (seedPhraseError.length ||
-                            errors.password ||
-                            errors.passwordConfirmation ||
-                            errors.acceptTOU ||
-                            isLoading) &&
+                        (isLoading || isImportDisabled) &&
                             "opacity-50 pointer-events-none"
                     )}
-                    disabled={
-                        seedPhraseError.length ||
-                        errors.password ||
-                        errors.passwordConfirmation ||
-                        errors.acceptTOU
-                            ? true
-                            : false
-                    }
+                    disabled={isImportDisabled || isLoading}
                 >
                     {!isLoading ? buttonLabel : <Spinner />}
                 </button>

--- a/packages/ui/src/routes/setup/PasswordSetupPage.tsx
+++ b/packages/ui/src/routes/setup/PasswordSetupPage.tsx
@@ -106,8 +106,7 @@ const PasswordSetupPage = () => {
             !errors.password
         ) {
             setIsSubmitDisabled(false)
-        }
-        else {
+        } else {
             setIsSubmitDisabled(true)
         }
     }, [passwordValues, errors.password])

--- a/packages/ui/src/routes/setup/PasswordSetupPage.tsx
+++ b/packages/ui/src/routes/setup/PasswordSetupPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Classes } from "../../styles/classes"
 
@@ -46,7 +46,7 @@ const PasswordSetupPage = () => {
     const history = useOnMountHistory()
     const [passwordScore, setPasswordScore] = useState<number>(0)
     const [isCreating, setIsCreating] = useState<boolean>(false)
-
+    const [isSubmitDisabled, setIsSubmitDisabled] = useState(true)
     // if the onboarding is ready the user shoulnd't set the password again.
     useCheckUserIsOnboarded()
 
@@ -54,7 +54,7 @@ const PasswordSetupPage = () => {
         register,
         handleSubmit,
         setError,
-
+        watch,
         formState: { errors },
     } = useForm<PasswordSetupFormData>({
         resolver: yupResolver(schema),
@@ -96,6 +96,21 @@ const PasswordSetupPage = () => {
             })
     })
 
+    const passwordValues = watch()
+    useEffect(() => {
+        if (
+            passwordValues.password &&
+            passwordValues.passwordConfirmation &&
+            passwordValues.password === passwordValues.passwordConfirmation &&
+            passwordValues.acceptTOU &&
+            !errors.password
+        ) {
+            setIsSubmitDisabled(false)
+        }
+        else {
+            setIsSubmitDisabled(true)
+        }
+    }, [passwordValues, errors.password])
     return (
         <PageLayout header maxWidth="max-w-md">
             <span className="my-6 text-lg font-bold font-title">
@@ -161,6 +176,7 @@ const PasswordSetupPage = () => {
                         isLoading={isCreating}
                         onClick={onSubmit}
                         buttonClass={Classes.button}
+                        disabled={isCreating || isSubmitDisabled}
                     ></ButtonWithLoading>
                 </div>
             </form>


### PR DESCRIPTION
# Name of the feature/issue
Enable submit button on Seed Import/New account

## Description
Add logic to enable submit button when importing or creating new account. It checks all the fields are completed, after that it enables the button.