### PR TITLE
[Feat] use custom headers with BlockWallet nodes

### DIFF
--- a/packages/background/src/controllers/NetworkController.ts
+++ b/packages/background/src/controllers/NetworkController.ts
@@ -10,6 +10,10 @@ import {
     EditNetworkUpdatesType,
     EditNetworkOrderType,
 } from '../utils/constants/networks';
+import {
+    isABlockWalletNode,
+    customHeadersForBlockWalletNode,
+} from '../utils/nodes';
 import { constants, ethers } from 'ethers';
 import { poll } from '@ethersproject/web';
 import { ErrorCode } from '@ethersproject/logger';
@@ -529,12 +533,16 @@ export default class NetworkController extends BaseController<NetworkControllerS
     };
 
     private _getProviderForNetwork(chainId: number, rpcUrl: string) {
+        const blockWalletNode = isABlockWalletNode(rpcUrl);
         return this._overloadProviderMethods(
             { chainId },
             new ethers.providers.StaticJsonRpcProvider(
                 {
                     url: rpcUrl,
-                    allowGzip: rpcUrl.endsWith('.blockwallet.io'),
+                    allowGzip: blockWalletNode,
+                    headers: blockWalletNode
+                        ? customHeadersForBlockWalletNode
+                        : undefined,
                 },
                 chainId
             )

--- a/packages/background/src/utils/ethereumChain.ts
+++ b/packages/background/src/utils/ethereumChain.ts
@@ -5,7 +5,10 @@ import {
     AddEthereumChainParameter,
     NormalizedAddEthereumChainParameter,
 } from './types/ethereum';
-
+import {
+    isABlockWalletNode,
+    customHeadersForBlockWalletNode,
+} from '../utils/nodes';
 /**
  * It validates and parses the chainId parameter checking if it's in the expected form
  *
@@ -81,7 +84,12 @@ export const validateNetworkChainId = async (
 export const getCustomRpcChainId = memoize(
     async (rpcUrl: string): Promise<number> => {
         // Check that chainId matches with network's
-        const tempProvider = new providers.StaticJsonRpcProvider(rpcUrl);
+        const tempProvider = new providers.StaticJsonRpcProvider({
+            url: rpcUrl,
+            headers: isABlockWalletNode(rpcUrl)
+                ? customHeadersForBlockWalletNode
+                : undefined,
+        });
         const { chainId: rpcChainId } = await tempProvider.getNetwork();
 
         return rpcChainId;

--- a/packages/background/src/utils/nodes.ts
+++ b/packages/background/src/utils/nodes.ts
@@ -1,0 +1,7 @@
+const BLOCK_WALLET_DOMAIN = '.blockwallet.io';
+
+export const isABlockWalletNode = (rpcUrl: string): boolean => {
+    return rpcUrl.endsWith(BLOCK_WALLET_DOMAIN);
+};
+
+export const customHeadersForBlockWalletNode = { wallet: 'BlockWallet' };


### PR DESCRIPTION
# Name of the feature/issue

Use custom headers when using BlockWallet nodes

## Description

- **Every request** to a BlockWallet node should have this custom header. More info at https://github.com/block-wallet/proxy-failover/pull/8