### PR TITLE
[Fix] Flashbots on Swaps

### DIFF
--- a/packages/ui/src/routes/swap/SwapConfirmPage.tsx
+++ b/packages/ui/src/routes/swap/SwapConfirmPage.tsx
@@ -581,6 +581,7 @@ const SwapPageConfirm: FC<{}> = () => {
                             flashbots: true,
                             slippage: true,
                         }}
+                        transactionGasLimit={selectedGasLimit}
                         setAdvancedSettings={(
                             newSettings: TransactionAdvancedData
                         ) => {


### PR DESCRIPTION
# Name of the feature/issue
Flashbots on Swaps

## Description
This PR fixes #258 which prevented Flashbots from being enabled in swap transactions. The fix consists on adding gas limit parameter to the advanced settings modal.