### PR TITLE
[Fix] Send to checksummed address with chain id

### DIFF
--- a/packages/ui/src/components/account/AccountDisplay.tsx
+++ b/packages/ui/src/components/account/AccountDisplay.tsx
@@ -27,6 +27,7 @@ import Tag from "../ui/Tag"
 import { isInternalAccount } from "../../util/account"
 import useCopyToClipboard from "../../util/hooks/useCopyToClipboard"
 import Dropdown from "../ui/Dropdown/Dropdown"
+import { toChecksumAddress } from "ethereumjs-util"
 
 interface ConfirmDialogState {
     isOpen: boolean
@@ -61,15 +62,17 @@ const AccountDisplay: FunctionComponent<AccountDisplayProps> = ({
     const [confirmationDialog, setConfirmationDialog] =
         useState<ConfirmDialogState>({ isOpen: false })
     const { isHovering: isHoveringMenu, getIsHoveringProps } = useIsHovering()
-    const { copied, onCopy } = useCopyToClipboard(account?.address)
     const { chainId, nativeCurrency } = useSelectedNetwork()
+    const checksumAddress = toChecksumAddress(account?.address, chainId)
+
+    const { copied, onCopy } = useCopyToClipboard(checksumAddress)
 
     const handleOptionClick = (optionMetadata: AccountMenuOptionMetadata) => {
         if (!optionMetadata.requiresConfirmation) {
-            return optionMetadata.handler!(account?.address)
+            return optionMetadata.handler!(checksumAddress)
         }
         setConfirmationDialog({
-            onConfirm: () => optionMetadata.handler!(account?.address),
+            onConfirm: () => optionMetadata.handler!(checksumAddress),
             isOpen: true,
             title: optionMetadata.confirmationTitle,
             message: optionMetadata.confirmationMessage,
@@ -104,7 +107,7 @@ const AccountDisplay: FunctionComponent<AccountDisplayProps> = ({
                 >
                     <AccountIcon
                         className="w-10 h-10"
-                        fill={getAccountColor(account?.address)}
+                        fill={getAccountColor(checksumAddress)}
                     />
                     <div className="flex flex-col">
                         <div
@@ -121,16 +124,16 @@ const AccountDisplay: FunctionComponent<AccountDisplayProps> = ({
                                         hoverStyle && "cursor-pointer"
                                     )}
                                     title={account.name}
-                                    htmlFor={`check-account-${account.address}`}
+                                    htmlFor={`check-account-${checksumAddress}`}
                                 >
                                     {accountName}
                                 </label>
                                 {!showAddress && (
                                     <span
                                         className="font-bold"
-                                        title={account.address}
+                                        title={checksumAddress}
                                     >
-                                        {formatHashLastChars(account.address)}
+                                        {formatHashLastChars(checksumAddress)}
                                     </span>
                                 )}
                             </div>
@@ -149,7 +152,7 @@ const AccountDisplay: FunctionComponent<AccountDisplayProps> = ({
                                 </span>
                             ) : (
                                 <span className="text-gray-500">
-                                    {formatHash(account?.address)}
+                                    {formatHash(checksumAddress)}
                                 </span>
                             )}
                             {copyAddressToClipboard && (

--- a/packages/ui/src/components/account/AccountDisplay.tsx
+++ b/packages/ui/src/components/account/AccountDisplay.tsx
@@ -28,6 +28,7 @@ import { isInternalAccount } from "../../util/account"
 import useCopyToClipboard from "../../util/hooks/useCopyToClipboard"
 import Dropdown from "../ui/Dropdown/Dropdown"
 import { toChecksumAddress } from "ethereumjs-util"
+import { useAddressWithChainIdChecksum } from "../../util/hooks/useSelectedAddressWithChainIdChecksum"
 
 interface ConfirmDialogState {
     isOpen: boolean
@@ -63,7 +64,7 @@ const AccountDisplay: FunctionComponent<AccountDisplayProps> = ({
         useState<ConfirmDialogState>({ isOpen: false })
     const { isHovering: isHoveringMenu, getIsHoveringProps } = useIsHovering()
     const { chainId, nativeCurrency } = useSelectedNetwork()
-    const checksumAddress = toChecksumAddress(account?.address, chainId)
+    const checksumAddress = useAddressWithChainIdChecksum(account?.address)
 
     const { copied, onCopy } = useCopyToClipboard(checksumAddress)
 

--- a/packages/ui/src/components/account/AccountMenu.tsx
+++ b/packages/ui/src/components/account/AccountMenu.tsx
@@ -1,4 +1,5 @@
 import { useSelectedAccount } from "../../context/hooks/useSelectedAccount"
+import { useSelectedAddressWithChainIdChecksum } from "../../util/hooks/useSelectedAddressWithChainIdChecksum"
 import VerticalSelect from "../input/VerticalSelect"
 import PopupHeader from "../popup/PopupHeader"
 import PopupLayout from "../popup/PopupLayout"
@@ -21,6 +22,7 @@ import { openHardwareRemove } from "../../context/commActions"
 const AccountMenu = () => {
     const { availableNetworks, selectedNetwork } = useBlankState()!
     const account = useSelectedAccount()
+    const checksumAddress = useSelectedAddressWithChainIdChecksum()
     const history = useOnMountHistory()
     const fromAccountList = history.location.state?.fromAccountList
     const explorerName = getExplorerTitle(availableNetworks, selectedNetwork)
@@ -53,7 +55,7 @@ const AccountMenu = () => {
             to: generateExplorerLink(
                 availableNetworks,
                 selectedNetwork,
-                account.address,
+                checksumAddress,
                 "address"
             ),
         },

--- a/packages/ui/src/components/account/AccountSearchResults.tsx
+++ b/packages/ui/src/components/account/AccountSearchResults.tsx
@@ -1,6 +1,5 @@
 import { AccountInfo } from "@block-wallet/background/controllers/AccountTrackerController"
-import { toChecksumAddress } from "ethereumjs-util"
-import { utils } from "ethers"
+import { isValidAddress, toChecksumAddress } from "ethereumjs-util"
 import { useRef, useEffect, useReducer } from "react"
 import { useAddressBookAccounts } from "../../context/hooks/useAddressBookAccounts"
 import { useSelectedNetwork } from "../../context/hooks/useSelectedNetwork"
@@ -65,6 +64,7 @@ const AccountSearchResults = ({
         !resultsToDisplay.wallet || results.wallet.length === 0
     const noAddressBookResults =
         !resultsToDisplay.addressBook || results.addressBook.length === 0
+
     const noEnsResults = !resultsToDisplay.ens || !results.ens
     const noUDResults = !resultsToDisplay.ud || !results.ud
     const displayEmptyResultsMessage = (): boolean => {
@@ -73,7 +73,7 @@ const AccountSearchResults = ({
             noAddressBookResults &&
             noEnsResults &&
             noUDResults &&
-            !utils.isAddress(filter) &&
+            !isValidAddress(filter) &&
             filter !== ""
         )
     }
@@ -139,7 +139,7 @@ const AccountSearchResults = ({
                                 key={account.address}
                                 account={account}
                                 selected={
-                                    utils.isAddress(filter) &&
+                                    isValidAddress(filter) &&
                                     toChecksumAddress(filter) ===
                                         account.address
                                 }

--- a/packages/ui/src/routes/PopupPage.tsx
+++ b/packages/ui/src/routes/PopupPage.tsx
@@ -34,6 +34,9 @@ import { session } from "../context/setup"
 import { useConnectedSite } from "../context/hooks/useConnectedSite"
 import { useTokensList } from "../context/hooks/useTokensList"
 
+// Utils
+import { useSelectedAddressWithChainIdChecksum } from "../util/hooks/useSelectedAddressWithChainIdChecksum"
+
 // Assets
 import TokenSummary from "../components/token/TokenSummary"
 import GasPricesInfo from "../components/gas/GasPricesInfo"
@@ -41,8 +44,7 @@ import DoubleArrowHoverAnimation from "../components/icons/DoubleArrowHoverAnima
 import TransparentOverlay from "../components/loading/TransparentOverlay"
 
 const AccountDisplay = () => {
-    const blankState = useBlankState()!
-    const accountAddress = blankState.selectedAddress
+    const accountAddress = useSelectedAddressWithChainIdChecksum()
     const account = useSelectedAccount()
     const [copied, setCopied] = useState(false)
     const copy = async () => {
@@ -145,11 +147,10 @@ const PopupPage = () => {
     const error = (useHistory().location.state as { error: string })?.error
     const state = useBlankState()!
     const history = useHistory()
-    const account = useSelectedAccount()
     const { nativeToken } = useTokensList()
     const { nativeCurrency, isSendEnabled, isSwapEnabled, isBridgeEnabled } =
         useSelectedNetwork()
-
+    const checksumAddress = useSelectedAddressWithChainIdChecksum()
     const [hasErrorDialog, setHasErrorDialog] = useState(!!error)
 
     const isLoading =
@@ -182,7 +183,7 @@ const PopupPage = () => {
                             >
                                 <AccountIcon
                                     className="w-8 h-8 transition-transform duration-200 ease-in transform hover:rotate-180"
-                                    fill={getAccountColor(account?.address)}
+                                    fill={getAccountColor(checksumAddress)}
                                 />
                             </Link>
                             <Tooltip

--- a/packages/ui/src/routes/send/SendPage.tsx
+++ b/packages/ui/src/routes/send/SendPage.tsx
@@ -12,7 +12,6 @@ import classnames from "classnames"
 import * as yup from "yup"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { useForm } from "react-hook-form"
-import { utils } from "ethers"
 
 import { useSelectedAccount } from "../../context/hooks/useSelectedAccount"
 import { useOnMountHistory } from "../../context/hooks/useOnMount"
@@ -25,7 +24,7 @@ import AccountSearchResults, {
     AccountResult,
 } from "../../components/account/AccountSearchResults"
 import Checkbox from "../../components/input/Checkbox"
-import { toChecksumAddress } from "ethereumjs-util"
+import { isValidAddress, toChecksumAddress } from "ethereumjs-util"
 import { formatHashLastChars } from "../../util/formatAccount"
 
 // Schema
@@ -34,7 +33,7 @@ const schema = yup.object().shape({
         .string()
         .required("No address provided.")
         .test("is-correct", "Address is incorrect", (address) => {
-            return utils.isAddress(`${address}`)
+            return isValidAddress(`${address}`)
         }),
 })
 type AddressFormData = { address: string }
@@ -111,13 +110,13 @@ const SendPage = () => {
 
     useEffect(() => {
         const checkAddress = () => {
-            const isValidAddress = utils.isAddress(searchString)
+            const validAddress = isValidAddress(searchString)
 
-            setIsAddress(isValidAddress)
+            setIsAddress(validAddress)
             setCanAddContact(false)
             setWarning("")
 
-            if (isValidAddress) {
+            if (validAddress) {
                 const normalizedAddress = toChecksumAddress(searchString)
 
                 const isCurrentAccount =

--- a/packages/ui/src/util/hooks/useSelectedAddressWithChainIdChecksum.ts
+++ b/packages/ui/src/util/hooks/useSelectedAddressWithChainIdChecksum.ts
@@ -6,9 +6,13 @@ const CHAIN_IDS_REQUIRE_EIP1191 = [30, 31]
 
 export const useSelectedAddressWithChainIdChecksum = (): string => {
     const { selectedAddress } = useBlankState()!
+    return useAddressWithChainIdChecksum(selectedAddress)
+}
+
+export const useAddressWithChainIdChecksum = (address: string): string => {
     const { chainId } = useSelectedNetwork()
     const eip1191ChainId = CHAIN_IDS_REQUIRE_EIP1191.includes(chainId)
         ? chainId
         : undefined
-    return toChecksumAddress(selectedAddress, eip1191ChainId)
+    return toChecksumAddress(address, eip1191ChainId)
 }

--- a/packages/ui/src/util/hooks/useSelectedAddressWithChainIdChecksum.ts
+++ b/packages/ui/src/util/hooks/useSelectedAddressWithChainIdChecksum.ts
@@ -1,0 +1,14 @@
+import { useBlankState } from "../../context/background/backgroundHooks"
+import { useSelectedNetwork } from "../../context/hooks/useSelectedNetwork"
+import { toChecksumAddress } from "ethereumjs-util"
+
+const CHAIN_IDS_REQUIRE_EIP1191 = [30, 31]
+
+export const useSelectedAddressWithChainIdChecksum = (): string => {
+    const { selectedAddress } = useBlankState()!
+    const { chainId } = useSelectedNetwork()
+    const eip1191ChainId = CHAIN_IDS_REQUIRE_EIP1191.includes(chainId)
+        ? chainId
+        : undefined
+    return toChecksumAddress(selectedAddress, eip1191ChainId)
+}


### PR DESCRIPTION
# Name of the feature/issue

Send to checksummed address with chain id

## Description

- Allow sending to a checksummed (with chain) address
- The copied value of the account should be checksummed with the chain id in RSK mainnet/testnet
- The copied value of the accounts in the transactions should be checksummed with the chain id in RSK mainnet/testnet
