### PR TITLE
[Fix] margin top in Tokensumarry

### DIFF
--- a/packages/ui/src/components/assets/AssetDetailsPage.tsx
+++ b/packages/ui/src/components/assets/AssetDetailsPage.tsx
@@ -167,7 +167,7 @@ const AssetDetailsPage = () => {
 
             <div className="flex flex-col items-start flex-1 w-full h-0 max-h-screen p-6 space-y-6 overflow-auto hide-scroll">
                 <TokenSummary minHeight="13rem" className="mt-2">
-                    <TokenSummary.Balances>
+                    <TokenSummary.Balances className="mt-2">
                         <AssetIcon filled asset={token} />
                         <TokenSummary.TokenName>
                             {token.name}

--- a/packages/ui/src/components/token/TokenSummary.tsx
+++ b/packages/ui/src/components/token/TokenSummary.tsx
@@ -4,7 +4,7 @@ import { useBlankState } from "../../context/background/backgroundHooks"
 import BalanceLoadingSkeleton from "../skeleton/BalanceLoadingSkeleton"
 
 interface TokenSummaryMembers {
-    Balances: FC<{ children: React.ReactNode }>
+    Balances: FC<{ children: React.ReactNode; className?: string }>
     TokenBalance: FC<{
         title?: string
         children: React.ReactNode
@@ -34,7 +34,13 @@ const TokenSummary: FC<{
     )
 }
 
-const Balances = ({ children }: { children: React.ReactNode }) => {
+const Balances = ({
+    children,
+    className,
+}: {
+    children: React.ReactNode
+    className?: string
+}) => {
     const state = useBlankState()!
 
     const isLoading =
@@ -45,7 +51,11 @@ const Balances = ({ children }: { children: React.ReactNode }) => {
             {isLoading ? (
                 <BalanceLoadingSkeleton />
             ) : (
-                <div className="flex flex-col items-center space-y-1 mt-2">
+                <div
+                    className={
+                        "flex flex-col items-center space-y-1 " + className
+                    }
+                >
                     {children}
                 </div>
             )}


### PR DESCRIPTION
# Name of the feature/issue
margin top in Tokensumarry

## Description
Remove margin-top from tokenSummary, it was only needed in AssetDetails, not in popuppage