### PR TITLE
handling eth_estimateGas request

### DIFF
--- a/packages/background/src/controllers/BlankController.ts
+++ b/packages/background/src/controllers/BlankController.ts
@@ -432,7 +432,8 @@ export default class BlankController extends EventEmitter {
             this.appStateController,
             this.keyringController,
             this.tokenController,
-            this.blockUpdatesController
+            this.blockUpdatesController,
+            this.gasPricesController
         );
 
         this.tokenAllowanceController = new TokenAllowanceController(

--- a/packages/background/src/utils/types/ethereum.ts
+++ b/packages/background/src/utils/types/ethereum.ts
@@ -263,6 +263,13 @@ export interface AddEthereumChainConfirmParams {
     saveImage: boolean;
 }
 
+export interface EstimateGasParams {
+    data: string;
+    from: string;
+    to: string;
+    value: string;
+}
+
 // EIP-712
 
 // Raw data for each method (Direct input from the provider)

--- a/packages/background/test/controllers/BlankProviderController.test.ts
+++ b/packages/background/test/controllers/BlankProviderController.test.ts
@@ -244,7 +244,8 @@ describe('Blank Provider Controller', function () {
             appStateController,
             new KeyringControllerDerivated({}),
             tokenController,
-            blockUpdatesController
+            blockUpdatesController,
+            gasPricesController
         );
 
         accountTrackerController.addPrimaryAccount(


### PR DESCRIPTION
# Name of the feature/issue

Gas estimation requests on provider.

## Description

This PR adds a handler for `eth_estimateGas` which adds some buffer to the chain gas estimation.

## Issue

Considering this fix all the gas estimations should be calculated ok, which affects this issue https://github.com/block-wallet/extension/issues/254. However, the user freely modifies the gas limit field, so in the last term, the amount of gas that the user decided will be used in the tx.
