### PR TITLE
Fix for cases where there is no 'value'

### DIFF
--- a/packages/background/src/controllers/BlankProviderController.ts
+++ b/packages/background/src/controllers/BlankProviderController.ts
@@ -81,6 +81,7 @@ import BlockUpdatesController, {
     BlockUpdatesEvents,
 } from './block-updates/BlockUpdatesController';
 import { Filter } from '@ethersproject/abstract-provider';
+import { Zero } from '@ethersproject/constants';
 import {
     parseBlock,
     validateLogSubscriptionRequest,
@@ -433,27 +434,56 @@ export default class BlankProviderController extends BaseController<BlankProvide
     private _handleEstimateGas = async (
         params: [EstimateGasParams]
     ): Promise<BigNumber> => {
-        const estimation = await this._transactionController.estimateGas({
-            transactionParams: {
-                data: params[0].data,
-                value: BigNumber.from(params[0].value),
-                from: params[0].from,
-                to: params[0].to,
-            } as TransactionParams,
-        } as TransactionMeta);
+        let gasLimit: BigNumber;
+        try {
+            let data = '';
+            if (typeof params[0].data !== 'undefined') {
+                data = params[0].data;
+            }
 
-        if (estimation.estimationSucceeded) {
-            return estimation.gasLimit;
+            let from = '';
+            if (typeof params[0].from !== 'undefined') {
+                from = params[0].from;
+            }
+
+            let to = '';
+            if (typeof params[0].to !== 'undefined') {
+                to = params[0].to;
+            }
+
+            let value = Zero;
+            if (typeof params[0].value !== 'undefined') {
+                value = BigNumber.from(params[0].value);
+            }
+
+            const estimation = await this._transactionController.estimateGas({
+                transactionParams: {
+                    data,
+                    value,
+                    from,
+                    to,
+                } as TransactionParams,
+            } as TransactionMeta);
+
+            gasLimit = estimation.gasLimit;
+        } catch (error) {
+            log.error('error estimating gas:', error);
+            try {
+                gasLimit = await this._networkController
+                    .getProvider()
+                    .send(JSONRPCMethod.eth_estimateGas, params);
+            } catch {
+                let { blockGasLimit } = this._gasPricesController.getState();
+                if (!bnGreaterThanZero(blockGasLimit)) {
+                    // London block size 30 millon gas units
+                    // https://ethereum.org/en/developers/docs/gas/#block-size
+                    blockGasLimit = BigNumber.from(30_000_000);
+                }
+                gasLimit = blockGasLimit;
+            }
         }
 
-        let { blockGasLimit } = this._gasPricesController.getState();
-        if (!bnGreaterThanZero(blockGasLimit)) {
-            // London block size 30 millon gas units
-            // https://ethereum.org/en/developers/docs/gas/#block-size
-            blockGasLimit = BigNumber.from(30_000_000);
-        }
-
-        return blockGasLimit;
+        return gasLimit;
     };
 
     /**


### PR DESCRIPTION
# Name of the feature/issue

Gas limit estimations w/o `value`.

## Description

This implementation aims to cover all the possibilities w/o throwing errors.
