### PR TITLE
[Fix]: Improve token allowance flow for bridges and swaps

### DIFF
--- a/packages/ui/src/components/dialog/WaitingAllowanceTransactionDialog.tsx
+++ b/packages/ui/src/components/dialog/WaitingAllowanceTransactionDialog.tsx
@@ -38,7 +38,8 @@ const WaitingAllowanceTransactionDialog: FC<Props> = ({
                 error: "Please try again. If the problem persists, please contact support.",
             }}
             clickOutsideToClose={false}
-            timeout={status === "success" ? 1000 : 3000}
+            //Less timeout for success message.
+            timeout={status === "success" ? 2000 : 3000}
             onDone={useCallback(() => {
                 if (status === "error") {
                     onError ? onError() : history.push("/")

--- a/packages/ui/src/components/dialog/WaitingAllowanceTransactionDialog.tsx
+++ b/packages/ui/src/components/dialog/WaitingAllowanceTransactionDialog.tsx
@@ -1,0 +1,72 @@
+import { FC, useCallback } from "react"
+import { useHistory } from "react-router-dom"
+import { boolean } from "yup"
+import ClickableText from "../button/ClickableText"
+import Divider from "../Divider"
+import WaitingDialog from "./WaitingDialog"
+
+type Operation = "swap" | "bridge"
+
+interface Props {
+    operation: Operation
+    isOpen: boolean
+    status: "idle" | "loading" | "success" | "error"
+    onError: () => void
+    onSuccess: () => void
+}
+
+const WaitingAllowanceTransactionDialog: FC<Props> = ({
+    isOpen,
+    status,
+    operation,
+    onError,
+    onSuccess,
+}) => {
+    const history = useHistory()
+    return (
+        <WaitingDialog
+            open={isOpen}
+            status={status}
+            titles={{
+                loading: "Waiting for allowance transaction...",
+                success: "Success",
+                error: "Allowance approval failed",
+            }}
+            texts={{
+                loading: <WaitingMessage operation={operation} />,
+                success: `The approval transaction has been mined. You can proceeed with the ${operation} now.`,
+                error: "Please try again. If the problem persists, please contact support.",
+            }}
+            clickOutsideToClose={false}
+            timeout={status === "success" ? 1000 : 3000}
+            onDone={useCallback(() => {
+                if (status === "error") {
+                    onError ? onError() : history.push("/")
+                    return
+                }
+                if (status === "success") {
+                    onSuccess()
+                }
+            }, [status, history])}
+        />
+    )
+}
+
+const WaitingMessage = ({ operation }: { operation: Operation }) => {
+    const history = useHistory()
+    return (
+        <div className="flex flex-col space-y-2 items-center">
+            <span>{`Your ${operation} is being prepared, please wait.`}</span>
+            <Divider />
+            <span className="text-xs">
+                {"You can wait here until it is done or "}
+                <ClickableText onClick={() => history.push("/")}>
+                    {`${operation} later`}
+                </ClickableText>
+                {" when the token approval is completed."}
+            </span>
+        </div>
+    )
+}
+
+export default WaitingAllowanceTransactionDialog

--- a/packages/ui/src/components/dialog/WaitingDialog.tsx
+++ b/packages/ui/src/components/dialog/WaitingDialog.tsx
@@ -41,6 +41,7 @@ type action =
               texts?: Partial<texts>
               titles?: Partial<texts>
               gifs?: gifs
+              forceOpen?: boolean
           }
       }
     | {
@@ -72,6 +73,7 @@ const reducer = (state: state, action: action) => {
                 texts: action.payload.texts,
                 titles: action.payload.titles,
                 gifs: action.payload.gifs,
+                isOpen: action.payload.forceOpen ? true : state.isOpen,
             }
     }
 }

--- a/packages/ui/src/context/hooks/useAwaitAllowanceTransactionDialog.tsx
+++ b/packages/ui/src/context/hooks/useAwaitAllowanceTransactionDialog.tsx
@@ -1,0 +1,59 @@
+import { TransactionMeta } from "@block-wallet/background/controllers/transactions/utils/types"
+import { useCallback, useEffect } from "react"
+import { useWaitingDialog } from "../../components/dialog/WaitingDialog"
+import { TransactionStatus } from "../commTypes"
+
+const useAwaitAllowanceTransactionDialog = (
+    transaction: TransactionMeta | undefined
+) => {
+    const { dispatch, status, isOpen } = useWaitingDialog({
+        defaultStatus: "idle",
+    })
+    useEffect(() => {
+        if (transaction?.status) {
+            if ([TransactionStatus.SUBMITTED].includes(transaction.status)) {
+                dispatch({
+                    type: "setStatus",
+                    payload: {
+                        status: "loading",
+                        forceOpen: true,
+                    },
+                })
+            }
+            if ([TransactionStatus.CONFIRMED].includes(transaction.status)) {
+                //Only dispatch success dialog if the dialog has been opened.
+                dispatch({
+                    type: "setStatus",
+                    payload: {
+                        status: "success",
+                        forceOpen: false,
+                    },
+                })
+            }
+            if (
+                [
+                    TransactionStatus.FAILED,
+                    TransactionStatus.DROPPED,
+                    TransactionStatus.CANCELLED,
+                ].includes(transaction.status)
+            ) {
+                dispatch({
+                    type: "setStatus",
+                    payload: {
+                        status: "error",
+                        forceOpen: true,
+                    },
+                })
+            }
+        }
+    }, [transaction?.status])
+    return {
+        status,
+        isOpen,
+        closeDialog: useCallback(() => {
+            dispatch({ type: "close" })
+        }, []),
+    }
+}
+
+export default useAwaitAllowanceTransactionDialog

--- a/packages/ui/src/routes/transaction/ApprovePage.tsx
+++ b/packages/ui/src/routes/transaction/ApprovePage.tsx
@@ -209,7 +209,6 @@ const ApprovePage: FunctionComponent<{}> = () => {
         useBlankState()!
     const { nativeToken } = useTokensList()
     const { gasPricesLevels } = useGasPriceData()
-
     const { status, isOpen, dispatch, texts, titles, closeDialog, gifs } =
         useTransactionWaitingDialog(
             inProgressTransaction
@@ -438,12 +437,11 @@ const ApprovePage: FunctionComponent<{}> = () => {
         }
 
         try {
-            let res: boolean = false
+            let allowanceResponse: boolean
 
             if (approveOperation === ApproveOperation.SWAP) {
                 const nextState = nextLocationState as SwapConfirmPageLocalState
-
-                res = await approveExchange(
+                allowanceResponse = await approveExchange(
                     assetAllowance,
                     BigNumber.from(nextState.swapQuote.fromTokenAmount),
                     ExchangeType.SWAP_1INCH,
@@ -466,7 +464,7 @@ const ApprovePage: FunctionComponent<{}> = () => {
                 const nextState =
                     nextLocationState as BridgeConfirmPageLocalState
 
-                res = await approveBridgeAllowance(
+                allowanceResponse = await approveBridgeAllowance(
                     assetAllowance,
                     BigNumber.from(
                         nextState.bridgeQuote.bridgeParams.params.fromAmount
@@ -489,7 +487,7 @@ const ApprovePage: FunctionComponent<{}> = () => {
                 )
             }
 
-            if (res) {
+            if (allowanceResponse) {
                 dispatch({
                     type: "setStatus",
                     payload: { status: "success" },
@@ -525,7 +523,10 @@ const ApprovePage: FunctionComponent<{}> = () => {
 
         history.push({
             pathname,
-            state: nextLocationState,
+            state: {
+                ...nextLocationState,
+                allowanceTransactionId: inProgressTransaction?.id,
+            },
         })
     }
 


### PR DESCRIPTION
# Name of the feature/issue
Improve allowance transactions status management for bridges and swaps

## Description
Currently, we are not managing pretty well the status an allowance transaction may transition in the middle of the swaps and bridges operations. Therefore, this PR listen to the status changes, shows proper messages and redirects user to the first step of the flow if the transaction has failed. 