### PR TITLE
[Fix] Improve swaps messages

### DIFF
--- a/packages/background/src/controllers/AccountTrackerController.ts
+++ b/packages/background/src/controllers/AccountTrackerController.ts
@@ -121,6 +121,7 @@ export enum AccountTrackerEvents {
     ACCOUNT_ADDED = 'ACCOUNT_ADDED',
     ACCOUNT_REMOVED = 'ACCOUNT_REMOVED',
     CLEARED_ACCOUNTS = 'CLEARED_ACCOUNTS',
+    BALANCE_UPDATED = 'BALANCE_UPDATED',
 }
 
 export interface UpdateAccountsOptions {
@@ -951,6 +952,13 @@ export class AccountTrackerController extends BaseController<AccountTrackerState
                 },
             },
         });
+
+        this.emit(
+            AccountTrackerEvents.BALANCE_UPDATED,
+            chainId,
+            accountAddress,
+            assetAddressToGetBalance
+        );
     }
 
     /**

--- a/packages/background/src/controllers/BlankController.ts
+++ b/packages/background/src/controllers/BlankController.ts
@@ -351,18 +351,6 @@ export default class BlankController extends EventEmitter {
             this.keyringController
         );
 
-        this.exchangeRatesController = new ExchangeRatesController(
-            initState.ExchangeRatesController,
-            this.preferencesController,
-            this.networkController,
-            this.blockUpdatesController,
-            () => {
-                return this.accountTrackerController.getAccountTokens(
-                    this.preferencesController.getSelectedAddress()
-                );
-            }
-        );
-
         this.transactionController = new TransactionController(
             this.networkController,
             this.preferencesController,
@@ -404,6 +392,14 @@ export default class BlankController extends EventEmitter {
             this.transactionWatcherController,
             this.transactionController,
             initState.AccountTrackerController
+        );
+
+        this.exchangeRatesController = new ExchangeRatesController(
+            initState.ExchangeRatesController,
+            this.preferencesController,
+            this.networkController,
+            this.blockUpdatesController,
+            this.accountTrackerController
         );
 
         this.blankProviderController = new BlankProviderController(

--- a/packages/background/src/controllers/ExchangeRatesController.ts
+++ b/packages/background/src/controllers/ExchangeRatesController.ts
@@ -3,7 +3,6 @@ import log from 'loglevel';
 import { PreferencesController } from './PreferencesController';
 import { BaseController } from '../infrastructure/BaseController';
 import { Token } from './erc-20/Token';
-import checksummedAddress from '../utils/checksummedAddress';
 import NetworkController, { NetworkEvents } from './NetworkController';
 import {
     ACTIONS_TIME_INTERVALS_DEFAULT_VALUES,
@@ -27,6 +26,11 @@ import {
     chainLinkService,
     coingekoService,
 } from '../utils/rateService';
+import {
+    AccountTrackerController,
+    AccountTrackerEvents,
+} from './AccountTrackerController';
+import { isNativeTokenAddress } from '../utils/token';
 
 export interface ExchangeRatesControllerState {
     exchangeRates: Rates;
@@ -68,11 +72,7 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
         private readonly _preferencesController: PreferencesController,
         private readonly _networkController: NetworkController,
         private readonly _blockUpdatesController: BlockUpdatesController,
-        private readonly getTokens: () => {
-            [address: string]: {
-                token: Token;
-            };
-        }
+        private readonly _accountTrackerController: AccountTrackerController
     ) {
         super(initState);
 
@@ -121,6 +121,35 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
                     }
                 );
             }
+        );
+
+        this._accountTrackerController.on(
+            AccountTrackerEvents.BALANCE_UPDATED,
+            () => {
+                const { exchangeRates } = this.store.getState();
+                const newTokenSymbols = Object.values(this.getTokens())
+                    .map(({ token }) => token)
+                    .filter(
+                        (token) =>
+                            !isNativeTokenAddress(token.address) &&
+                            exchangeRates[token.symbol] === undefined
+                    );
+                if (newTokenSymbols.length) {
+                    //when there are new token symbols, force fetching.
+                    this._exchangeRateFetchIntervalController.tick(
+                        0, //force update with 0 interval
+                        async () => {
+                            await this.updateExchangeRates();
+                        }
+                    );
+                }
+            }
+        );
+    }
+
+    private getTokens() {
+        return this._accountTrackerController.getAccountTokens(
+            this._preferencesController.getSelectedAddress()
         );
     }
 
@@ -203,17 +232,20 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
         // Get tokens exchange rates
         const tokenRatesQuery = await this._getTokenRates();
 
-        // Response -> {[contractAddress] : { [nativeCurrency] : rate }} | {}
-        Object.keys(tokenRatesQuery).forEach((contractAddress) => {
-            // Need to checksumm address given that the current assets list
-            const address = checksummedAddress(contractAddress);
-            const tokens = { ...this.staticTokens, ...this.getTokens() };
-            const { symbol } = tokens[address].token;
+        const tokens = { ...this.staticTokens, ...this.getTokens() };
+
+        Object.keys(tokens).forEach((contractAddress) => {
+            const lowerAddress = contractAddress.toLowerCase();
+            //TODO: Improve the way we store "unknown" convertion rates.
+            const rate = tokenRatesQuery[lowerAddress] ||
+                tokenRatesQuery[contractAddress] || {
+                    [this._preferencesController.nativeCurrency]: 0,
+                }; //Force 0 if the convertion is not returned.
+
+            const { symbol } = tokens[contractAddress].token;
             if (symbol) {
                 rates[symbol] =
-                    tokenRatesQuery[contractAddress][
-                        this._preferencesController.nativeCurrency
-                    ];
+                    rate[this._preferencesController.nativeCurrency];
             }
         });
 
@@ -224,7 +256,9 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
     /**
      * Gets the exchange rate for all tokens
      */
-    private _getTokenRates = async (): Promise<any> => {
+    private _getTokenRates = async (): Promise<{
+        [lowerCaseAddress: string]: { [currency: string]: number };
+    }> => {
         const tokens = { ...this.staticTokens, ...this.getTokens() };
         const tokenContracts = Object.keys(tokens).join(',');
 

--- a/packages/background/src/controllers/block-updates/ActionIntervalController.ts
+++ b/packages/background/src/controllers/block-updates/ActionIntervalController.ts
@@ -24,8 +24,9 @@ export class ActionIntervalController {
         interval: Duration,
         cb: () => Promise<T>
     ): Promise<void> {
-        const _currentTimestamp = currentTimestamp();
-        if (_currentTimestamp - this._currentTimestamp >= interval) {
+        const _now = currentTimestamp();
+        const timeEllapsedSinceLastUpdate = _now - this._currentTimestamp;
+        if (timeEllapsedSinceLastUpdate >= interval) {
             await this._mutex.runExclusive(async () => {
                 this._updateCurrentTimestamp(currentTimestamp());
                 try {

--- a/packages/background/src/utils/1inchError.ts
+++ b/packages/background/src/utils/1inchError.ts
@@ -1,23 +1,28 @@
 import { RequestError } from './http';
 
 const EXACT_MATCH_ERRORS = ['Insufficient liquidity', 'Cannot estimate'];
+const NOT_ENOUGH_BALANCE = `Balance too low to cover swap and gas cost.`;
 
 const MAPPED_ERRORS: { regex: RegExp; errorMessage: string }[] = [
     {
         regex: /balance for gas fee/i,
-        errorMessage: "You don't have enough balance for covering gas costs.",
+        errorMessage: NOT_ENOUGH_BALANCE,
+    },
+    {
+        regex: /may not have enough ETH balance/i,
+        errorMessage: NOT_ENOUGH_BALANCE,
     },
     {
         regex: /forget about miner fee./i,
-        errorMessage: "You don't have enough balance for covering gas costs.",
+        errorMessage: NOT_ENOUGH_BALANCE,
     },
     {
         regex: /enough balance/i,
-        errorMessage: 'Insufficient funds.',
+        errorMessage: NOT_ENOUGH_BALANCE,
     },
     {
         regex: /not enough/i,
-        errorMessage: 'Insufficient funds.',
+        errorMessage: NOT_ENOUGH_BALANCE,
     },
     {
         regex: /enough allowance/i,

--- a/packages/background/test/controllers/ExchangeRatesController.test.ts
+++ b/packages/background/test/controllers/ExchangeRatesController.test.ts
@@ -1,32 +1,29 @@
 import { expect } from 'chai';
-import {
-    mockExchangeRatesController,
-    mockExchangeRatesControllerARS,
-} from '../mocks/mock-exchangerates';
+import { getExchangeRateMockController } from '../mocks/mock-exchangerates';
 import { ExchangeRatesController } from '@block-wallet/background/controllers/ExchangeRatesController';
 import sinon from 'sinon';
 
 describe('Exchange Rates Controller', function () {
     let exchangeRatesController: ExchangeRatesController;
     let exchangeRatesControllerARS: ExchangeRatesController;
-
-    this.beforeAll(() => {
-        exchangeRatesController = mockExchangeRatesController;
-        exchangeRatesControllerARS = mockExchangeRatesControllerARS;
-        sinon
+    const exchangeRateSandox = sinon.createSandbox();
+    before(() => {
+        exchangeRatesController = getExchangeRateMockController('USD');
+        exchangeRatesControllerARS = getExchangeRateMockController('ARS');
+        exchangeRateSandox
             .stub(exchangeRatesController as any, '_getTokenRates')
             .returns(Promise.resolve([]));
     });
 
     afterEach(function () {
-        sinon.restore();
+        exchangeRateSandox.restore();
     });
 
     it('ETH-USD - it should feed the exchangeRates object', async function () {
         expect(exchangeRatesController.store.getState().exchangeRates).to.be
             .empty;
 
-        sinon
+        exchangeRateSandox
             .stub(exchangeRatesController['_exchangeRateService'], 'getRate')
             .returns(Promise.resolve(1225));
 
@@ -39,20 +36,22 @@ describe('Exchange Rates Controller', function () {
     });
 
     it('ETH-ARS - it should feed the exchangeRates object', async function () {
-        sinon.stub(exchangeRatesControllerARS as any, '_getTokenRates').returns(
-            Promise.resolve(
-                Promise.resolve({
-                    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
-                        usd: 1.001,
-                    },
-                    '0xdac17f958d2ee523a2206206994597c13d831ec7': {
-                        usd: 1.001,
-                    },
-                })
-            )
-        );
+        exchangeRateSandox
+            .stub(exchangeRatesControllerARS as any, '_getTokenRates')
+            .returns(
+                Promise.resolve(
+                    Promise.resolve({
+                        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
+                            usd: 1.001,
+                        },
+                        '0xdac17f958d2ee523a2206206994597c13d831ec7': {
+                            usd: 1.001,
+                        },
+                    })
+                )
+            );
 
-        sinon
+        exchangeRateSandox
             .stub(exchangeRatesControllerARS['_exchangeRateService'], 'getRate')
             .returns(Promise.resolve(50000));
 
@@ -65,10 +64,10 @@ describe('Exchange Rates Controller', function () {
     });
 
     it('AVX-USD - it should feed the exchangeRates object', async function () {
-        sinon
+        exchangeRateSandox
             .stub(exchangeRatesController.store.getState(), 'exchangeRates')
             .value({ ['AVX']: 0 });
-        sinon
+        exchangeRateSandox
             .stub(
                 exchangeRatesController.store.getState(),
                 'networkNativeCurrency'
@@ -77,11 +76,11 @@ describe('Exchange Rates Controller', function () {
                 symbol: 'AVX',
                 coingeckoPlatformId: '333999',
             });
-        sinon
+        exchangeRateSandox
             .stub(exchangeRatesController as any, '_getTokenRates')
             .returns(Promise.resolve([]));
 
-        sinon
+        exchangeRateSandox
             .stub(exchangeRatesController['_exchangeRateService'], 'getRate')
             .returns(Promise.resolve(125));
 

--- a/packages/ui/src/components/assets/AssetSelection.tsx
+++ b/packages/ui/src/components/assets/AssetSelection.tsx
@@ -47,6 +47,21 @@ interface AssetSelectionProps {
 const ZERO_BN = BigNumber.from(0)
 const SEARCH_LIMIT = 20
 
+function mergeAssetList(
+    baseList: TokenWithBalance[],
+    mergeList: TokenWithBalance[]
+): TokenWithBalance[] {
+    const baseListAddresses = baseList.map(({ token }) =>
+        token.address.toLowerCase()
+    )
+    return baseList.concat(
+        mergeList.filter(
+            ({ token }) =>
+                !baseListAddresses.includes(token.address.toLowerCase())
+        )
+    )
+}
+
 export const AssetSelection: FC<AssetSelectionProps> = ({
     onAssetChange,
     selectedAssetList,
@@ -84,7 +99,7 @@ export const AssetSelection: FC<AssetSelectionProps> = ({
         const searchAll = async () => {
             // If there is no search return the list of swapped assets
             if (!search) {
-                setSearchResult(swappedAssetList)
+                setSearchResult(mergeAssetList(swappedAssetList, assetList))
                 return
             }
 

--- a/packages/ui/src/components/swaps/HighPriceImpactDialog.tsx
+++ b/packages/ui/src/components/swaps/HighPriceImpactDialog.tsx
@@ -1,0 +1,95 @@
+import { BasicToken } from "@block-wallet/background/utils/types/1inch"
+import { BigNumber } from "ethers"
+import { formatUnits } from "ethers/lib/utils"
+import { FC } from "react"
+import { formatRounded } from "../../util/formatRounded"
+import useCurrencyFromatter from "../../util/hooks/useCurrencyFormatter"
+import WarningDialog from "../dialog/WarningDialog"
+
+interface HighPriceImpactDialogProps {
+    onClose: () => void
+    isOpen: boolean
+    priceImpactPercentage: number | undefined
+    fromToken: { amount: BigNumber; token: BasicToken }
+    toToken: { amount: BigNumber; token: BasicToken }
+}
+const UNABLE_TO_CALCULATE_PRICE_TITLE = "Unable to calculate price impact"
+const UNABLE_TO_CALCULATE_PRICE_MESSAGE =
+    "Please review the rates of your swap to avoid potential losses."
+
+const HIGH_PRICE_IMPACT_TITLE = "High price impact!"
+
+const HighPriceImpactExplained: FC<
+    Pick<
+        HighPriceImpactDialogProps,
+        "fromToken" | "toToken" | "priceImpactPercentage"
+    >
+> = ({ fromToken, toToken, priceImpactPercentage }) => {
+    const { format } = useCurrencyFromatter()
+    const formatToken = (t: BasicToken, amount: BigNumber): string => {
+        return `${formatRounded(formatUnits(amount || "0", t.decimals), 5)} ${
+            t.symbol
+        }`
+    }
+    return (
+        <div className="flex flex-col space-y-3">
+            Warning! We detected a {(priceImpactPercentage! * 100).toFixed(2)}%
+            difference in the values you are about to swap.
+            <div className="flex flex-col space-y-2 text-left mt-2">
+                <div>
+                    <span className="font-bold text-black">You pay</span>
+                    <br />
+                    {`${formatToken(fromToken.token, fromToken.amount)} ~=
+                    ${format(
+                        fromToken.amount,
+                        fromToken.token.symbol,
+                        fromToken.token.decimals
+                    )}`}
+                </div>
+                <div className="mt-2">
+                    <span className="font-bold">You get</span>
+                    <br />
+                    {`${formatToken(
+                        toToken.token,
+                        toToken.amount
+                    )} ~=   ${format(
+                        toToken.amount,
+                        toToken.token.symbol,
+                        toToken.token.decimals
+                    )}`}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const PriceImpactDialog: FC<HighPriceImpactDialogProps> = ({
+    isOpen,
+    onClose,
+    priceImpactPercentage,
+    fromToken,
+    toToken,
+}) => {
+    let title: string = UNABLE_TO_CALCULATE_PRICE_TITLE
+    let message: React.ReactElement | string = UNABLE_TO_CALCULATE_PRICE_MESSAGE
+    if (priceImpactPercentage) {
+        title = HIGH_PRICE_IMPACT_TITLE
+        message = (
+            <HighPriceImpactExplained
+                fromToken={fromToken}
+                toToken={toToken}
+                priceImpactPercentage={priceImpactPercentage}
+            />
+        )
+    }
+    return (
+        <WarningDialog
+            open={isOpen}
+            message={message}
+            title={title}
+            onDone={onClose}
+        />
+    )
+}
+
+export default PriceImpactDialog

--- a/packages/ui/src/components/swaps/PriceImpactDialog.tsx
+++ b/packages/ui/src/components/swaps/PriceImpactDialog.tsx
@@ -47,7 +47,7 @@ const HighPriceImpactExplained: FC<
                     )}`}
                 </div>
                 <div className="mt-2">
-                    <span className="font-bold">You get</span>
+                    <span className="font-bold text-black">You get</span>
                     <br />
                     {`${formatToken(
                         toToken.token,

--- a/packages/ui/src/components/transactions/GasPriceComponent.tsx
+++ b/packages/ui/src/components/transactions/GasPriceComponent.tsx
@@ -758,7 +758,8 @@ const GasPriceComponent: FunctionComponent<{
             <div
                 className={classnames(
                     Classes.blueSection,
-                    active && Classes.blueSectionActive
+                    active && Classes.blueSectionActive,
+                    disabled && "pointer-events-none"
                 )}
                 onClick={() =>
                     !disabled &&
@@ -842,7 +843,7 @@ const GasPriceComponent: FunctionComponent<{
                 open={showEstimationWarning}
                 onDone={() => setShowEstimationWarning(false)}
                 title="Gas estimation failed"
-                message="There was an error estimating fee values. This transaction might fail when confirmed."
+                message="The provided gas estimation could be incorrect. Please review gas settings before submitting."
             />
             {/* Modal */}
 

--- a/packages/ui/src/components/transactions/GasPriceSelector.tsx
+++ b/packages/ui/src/components/transactions/GasPriceSelector.tsx
@@ -585,7 +585,8 @@ export const GasPriceSelector = (props: GasPriceSelectorProps) => {
             <div
                 className={classnames(
                     Classes.blueSection,
-                    active && Classes.blueSectionActive
+                    active && Classes.blueSectionActive,
+                    disabled && "pointer-events-none"
                 )}
                 onClick={() =>
                     !disabled &&
@@ -639,7 +640,7 @@ export const GasPriceSelector = (props: GasPriceSelectorProps) => {
                 open={showEstimationWarning}
                 onDone={() => setShowEstimationWarning(false)}
                 title="Gas estimation failed"
-                message="There was an error estimating fee values. This transaction might fail when confirmed."
+                message="The provided gas estimation could be incorrect. Please review gas settings before submitting."
             />
             <Dialog open={active} onClickOutside={() => setActive(false)}>
                 <span className="absolute top-0 right-0 p-4 z-50">

--- a/packages/ui/src/components/ui/Alert.tsx
+++ b/packages/ui/src/components/ui/Alert.tsx
@@ -1,8 +1,9 @@
 import classnames from "classnames"
-import { PropsWithChildren } from "react"
+import { MouseEventHandler, PropsWithChildren } from "react"
 interface AlertProps {
     type: "error" | "warn" | "info"
     className?: string
+    onClick?: () => any
 }
 
 const CLASSES_BY_TYPE = {
@@ -21,12 +22,14 @@ const CLASSES_BY_TYPE = {
 }
 const Alert: React.FC<PropsWithChildren<AlertProps>> = ({
     type,
+    onClick,
     children,
     className,
 }) => {
     const classes = CLASSES_BY_TYPE[type]
     return (
         <div
+            onClick={onClick}
             className={classnames(
                 classes.background,
                 "opacity-90 rounded-md w-full p-4 flex space-x-2 items-center font-bold justify-center",

--- a/packages/ui/src/routes/swap/SwapConfirmPage.tsx
+++ b/packages/ui/src/routes/swap/SwapConfirmPage.tsx
@@ -77,7 +77,7 @@ import useAwaitAllowanceTransactionDialog from "../../context/hooks/useAwaitAllo
 import WaitingAllowanceTransactionDialog from "../../components/dialog/WaitingAllowanceTransactionDialog"
 import ErrorMessage from "../../components/error/ErrorMessage"
 import Alert from "../../components/ui/Alert"
-import PriceImpactDialog from "../../components/swaps/HighPriceImpactDialog"
+import PriceImpactDialog from "../../components/swaps/PriceImpactDialog"
 
 export interface SwapConfirmPageLocalState {
     fromToken: Token

--- a/packages/ui/src/routes/swap/SwapConfirmPage.tsx
+++ b/packages/ui/src/routes/swap/SwapConfirmPage.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../context/commTypes"
 import {
     calcExchangeRate,
+    calculatePricePercentageImpact,
     isSwapNativeTokenAddress,
     populateExchangeTransaction,
 } from "../../util/exchangeUtils"
@@ -74,6 +75,9 @@ import { useBlankState } from "../../context/background/backgroundHooks"
 import { useTransactionById } from "../../context/hooks/useTransactionById"
 import useAwaitAllowanceTransactionDialog from "../../context/hooks/useAwaitAllowanceTransactionDialog"
 import WaitingAllowanceTransactionDialog from "../../components/dialog/WaitingAllowanceTransactionDialog"
+import ErrorMessage from "../../components/error/ErrorMessage"
+import Alert from "../../components/ui/Alert"
+import PriceImpactDialog from "../../components/swaps/HighPriceImpactDialog"
 
 export interface SwapConfirmPageLocalState {
     fromToken: Token
@@ -83,16 +87,22 @@ export interface SwapConfirmPageLocalState {
     allowanceTransactionId?: string
 }
 
+const NOT_ENOUGH_BALANCE_ERROR =
+    "Balance too low to cover swap and gas cost. Please review gas configuration."
+
 // 15s
 const QUOTE_REFRESH_TIMEOUT = 1000 * 15
+const PRICE_IMPACT_THRESHOLD = 0.1
 
 const SwapPageConfirm: FC<{}> = () => {
     const history = useOnMountHistory()
+    const { exchangeRates } = useBlankState()!
     const { fromToken, swapQuote, toToken, allowanceTransactionId } = useMemo(
         () => history.location.state as SwapConfirmPageLocalState,
         [history.location.state]
     )
-
+    const [isPriceImpactDialogOpened, setIsPriceImpactDialogOpened] =
+        useState<boolean>(false)
     const [timeoutStart, setTimeoutStart] = useState<number | undefined>(
         undefined
     )
@@ -178,6 +188,23 @@ const SwapPageConfirm: FC<{}> = () => {
     const [advancedSettings, setAdvancedSettings] = useState<
         WithRequired<TransactionAdvancedData, "slippage">
     >(defaultAdvancedSettings)
+
+    const pricePercentageImpact = useMemo(() => {
+        if (swapParameters) {
+            return calculatePricePercentageImpact(
+                exchangeRates,
+                {
+                    token: swapParameters.fromToken,
+                    amount: BigNumber.from(swapParameters.fromTokenAmount ?? 0),
+                },
+                {
+                    token: swapParameters.toToken,
+                    amount: BigNumber.from(swapParameters.toTokenAmount ?? 0),
+                }
+            )
+        }
+        return undefined
+    }, [swapParameters, exchangeRates])
 
     // Gas
     const [defaultGas, setDefaultGas] = useState<{
@@ -289,6 +316,7 @@ const SwapPageConfirm: FC<{}> = () => {
 
     const updateSwapParameters = useCallback(async () => {
         setError(undefined)
+        setIsFetchingSwaps(true)
         const params: OneInchSwapRequestParams = {
             fromAddress: selectedAccount.address,
             fromTokenAddress: swapQuote.fromToken.address,
@@ -296,17 +324,16 @@ const SwapPageConfirm: FC<{}> = () => {
             amount: swapQuote.fromTokenAmount,
             slippage: advancedSettings.slippage,
         }
-        setIsFetchingSwaps(true)
         try {
             const swapParams = await getExchangeParameters(
                 ExchangeType.SWAP_1INCH,
                 params
             )
             setSwapParameters(swapParams)
-            setTimeoutStart(new Date().getTime())
         } catch (error) {
             setError(capitalize(error.message || "Error fetching swap"))
         } finally {
+            setTimeoutStart(new Date().getTime())
             setIsFetchingSwaps(false)
         }
     }, [
@@ -320,7 +347,7 @@ const SwapPageConfirm: FC<{}> = () => {
     // Initialize gas
     useEffect(() => {
         const setGas = async () => {
-            if (!swapParameters && error) {
+            if ((!swapParameters && error) || !hasBalance) {
                 setIsGasLoading(false)
             }
             if (swapParameters && isGasInitialized.current === false) {
@@ -350,22 +377,26 @@ const SwapPageConfirm: FC<{}> = () => {
         setGas()
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [swapParameters, error])
+    }, [swapParameters, error, hasBalance])
 
     useEffect(() => {
         if (!shouldFetchSwapParams || isInProgressAllowanceTransaction) {
             setTimeoutStart(undefined)
             return
         }
-        //first render, run function manually
-        updateSwapParameters()
-        let intervalRef = setInterval(
-            updateSwapParameters,
-            QUOTE_REFRESH_TIMEOUT
-        )
+
+        let timeoutRef: ReturnType<typeof setTimeout>
+
+        async function fetchParams() {
+            await updateSwapParameters()
+            timeoutRef = setTimeout(fetchParams, QUOTE_REFRESH_TIMEOUT)
+        }
+
+        fetchParams()
+
         // Cleanup timer
         return () => {
-            intervalRef && clearInterval(intervalRef)
+            timeoutRef && clearTimeout(timeoutRef)
         }
     }, [
         updateSwapParameters,
@@ -382,6 +413,18 @@ const SwapPageConfirm: FC<{}> = () => {
             swapParameters?.toTokenAmount || swapQuote.toTokenAmount
         )
     }, [swapParameters?.toTokenAmount, swapQuote.toTokenAmount])
+
+    let errMessage = error
+
+    //Override to custom error.
+    if (!hasBalance && swapParameters) {
+        errMessage = NOT_ENOUGH_BALANCE_ERROR
+    }
+
+    const priceImpactWarning =
+        pricePercentageImpact !== undefined
+            ? pricePercentageImpact > PRICE_IMPACT_THRESHOLD
+            : !!swapParameters
 
     return (
         <PopupLayout
@@ -402,17 +445,9 @@ const SwapPageConfirm: FC<{}> = () => {
             footer={
                 <PopupFooter>
                     <ButtonWithLoading
-                        label={
-                            error
-                                ? error
-                                : hasBalance
-                                ? `Swap`
-                                : isSwappingNativeToken
-                                ? "You don't have enough funds to cover the swap and the gas costs."
-                                : "Insufficient funds"
-                        }
+                        label="Swap"
                         isLoading={
-                            error || isInProgressAllowanceTransaction
+                            errMessage || isInProgressAllowanceTransaction
                                 ? false
                                 : !swapParameters ||
                                   isGasLoading ||
@@ -420,12 +455,7 @@ const SwapPageConfirm: FC<{}> = () => {
                                   isSwapping
                         }
                         onClick={onSubmit}
-                        disabled={!!error || !hasBalance}
-                        buttonClass={classnames(
-                            error || !hasBalance
-                                ? `${Classes.redButton} opacity-100`
-                                : ""
-                        )}
+                        disabled={!!errMessage}
                     />
                 </PopupFooter>
             }
@@ -501,7 +531,23 @@ const SwapPageConfirm: FC<{}> = () => {
                 rate={rate}
                 threshold={advancedSettings.slippage}
             />
-            <div className="flex flex-col px-6 py-3">
+            {swapParameters && (
+                <PriceImpactDialog
+                    isOpen={isPriceImpactDialogOpened}
+                    fromToken={{
+                        token: swapParameters.fromToken,
+                        amount: BigNumber.from(swapParameters.fromTokenAmount),
+                    }}
+                    toToken={{
+                        token: swapParameters.toToken,
+                        amount: BigNumber.from(swapParameters.toTokenAmount),
+                    }}
+                    onClose={() => setIsPriceImpactDialogOpened(false)}
+                    priceImpactPercentage={pricePercentageImpact}
+                />
+            )}
+
+            <div className="flex flex-col px-6 py-3 h-full">
                 {/* From Token */}
                 <AssetAmountDisplay
                     asset={fromToken}
@@ -512,7 +558,7 @@ const SwapPageConfirm: FC<{}> = () => {
                 />
 
                 {/* Divider */}
-                <div className="pt-8">
+                <div className="pt-5">
                     <hr className="-mx-5" />
                     <div className="flex -translate-y-2/4 justify-center items-center mx-auto rounded-full w-8 h-8 border border-grey-200 bg-white z-10">
                         <img
@@ -532,7 +578,7 @@ const SwapPageConfirm: FC<{}> = () => {
                 />
 
                 {/* Rates */}
-                <p className="text-sm py-2 leading-loose text-gray-500 uppercase text-center w-full">
+                <p className="text-sm py-1 leading-loose text-gray-500 uppercase text-center w-full">
                     {`1 ${fromToken.symbol} = ${formatNumberLength(
                         formatRounded(exchangeRate.toFixed(10), 8),
                         10
@@ -540,7 +586,7 @@ const SwapPageConfirm: FC<{}> = () => {
                 </p>
 
                 {/* Gas */}
-                <p className="text-sm text-gray-600 pb-2 pt-1">Gas Price</p>
+                <p className="text-sm text-gray-600 pb-1 pt-0.5">Gas Price</p>
                 {isEIP1559Compatible ? (
                     <GasPriceComponent
                         defaultGas={{
@@ -557,8 +603,13 @@ const SwapPageConfirm: FC<{}> = () => {
                                     gasFees.maxPriorityFeePerGas!,
                             })
                         }}
+                        minGasLimit={
+                            swapParameters
+                                ? swapParameters.tx.gas.toString()
+                                : undefined
+                        }
                         isParentLoading={isGasLoading}
-                        disabled={isGasLoading}
+                        disabled={isGasLoading || !swapParameters}
                         displayOnlyMaxValue
                     />
                 ) : (
@@ -571,7 +622,7 @@ const SwapPageConfirm: FC<{}> = () => {
                             setSelectedGasLimit(gasLimit)
                         }}
                         isParentLoading={isGasLoading}
-                        disabled={isGasLoading}
+                        disabled={isGasLoading || !swapParameters}
                     />
                 )}
 
@@ -614,10 +665,53 @@ const SwapPageConfirm: FC<{}> = () => {
                         <Icon name={IconName.RIGHT_CHEVRON} size="sm" />
                     </OutlinedButton>
                 </div>
-
-                {remainingSuffix && (
-                    <RefreshLabel value={remainingSuffix} className="mt-3" />
-                )}
+                <div className="h-full flex flex-col justify-end space-y-3">
+                    {isFetchingSwaps ? (
+                        <div />
+                    ) : (
+                        <>
+                            {errMessage ? (
+                                <ErrorMessage>{errMessage}</ErrorMessage>
+                            ) : priceImpactWarning ? (
+                                <Alert
+                                    type="warn"
+                                    className={classnames(
+                                        "p-2",
+                                        "font-bold",
+                                        "cursor-pointer hover:opacity-50",
+                                        "text-left"
+                                    )}
+                                    onClick={() =>
+                                        setIsPriceImpactDialogOpened(true)
+                                    }
+                                >
+                                    <span>
+                                        {pricePercentageImpact ? (
+                                            <span>
+                                                High price impact! More than{" "}
+                                                {(
+                                                    pricePercentageImpact * 100
+                                                ).toFixed(2)}
+                                                % loss
+                                            </span>
+                                        ) : (
+                                            <span>
+                                                Unable to calculate the price
+                                                impact
+                                            </span>
+                                        )}
+                                    </span>
+                                </Alert>
+                            ) : null}
+                            {remainingSuffix && (
+                                <RefreshLabel
+                                    value={remainingSuffix}
+                                    className="pb-1"
+                                />
+                            )}
+                        </>
+                    )}
+                </div>
             </div>
         </PopupLayout>
     )

--- a/packages/ui/src/routes/swap/SwapPage.tsx
+++ b/packages/ui/src/routes/swap/SwapPage.tsx
@@ -389,15 +389,10 @@ const SwapPage = () => {
             footer={
                 <PopupFooter>
                     <ButtonWithLoading
-                        label={
-                            error ? error : hasAllowance ? "Review" : "Approve"
-                        }
+                        label={hasAllowance ? "Review" : "Approve"}
                         disabled={!!(error || !quote)}
                         isLoading={isLoading}
                         onClick={onSubmit}
-                        buttonClass={classnames(
-                            error && `${Classes.redButton} opacity-100`
-                        )}
                     />
                 </PopupFooter>
             }
@@ -410,7 +405,7 @@ const SwapPage = () => {
                     rate={rate}
                 />
             ) : null}
-            <div className="flex flex-col p-6">
+            <div className="flex flex-col px-6 py-4 h-full">
                 <div
                     className={classnames(
                         "flex flex-row",
@@ -549,7 +544,7 @@ const SwapPage = () => {
                 <p className="text-sm text-gray-600 pb-3">Swap To</p>
                 <AssetSelection
                     displayIcon
-                    selectedAssetList={AssetListType.ALL}
+                    selectedAssetList={AssetListType.DEFAULT}
                     selectedAsset={
                         tokenTo
                             ? {
@@ -585,10 +580,19 @@ const SwapPage = () => {
                         <span>{`BlockWallet fee (${BASE_SWAP_FEE}%): ${swapFee}`}</span>
                     </div>
                 )}
+                <div className="h-full flex flex-col justify-end space-y-3">
+                    {error && (
+                        <div>
+                            <ErrorMessage>{error}</ErrorMessage>
+                        </div>
+                    )}
+                    {remainingSuffix && (
+                        <div className="flex flex-col justify-end">
+                            <RefreshLabel value={remainingSuffix} />
+                        </div>
+                    )}
+                </div>
             </div>
-            {remainingSuffix && (
-                <RefreshLabel value={remainingSuffix} className="ml-6 mt-12" />
-            )}
         </PopupLayout>
     )
 }

--- a/packages/ui/src/util/hooks/useCurrencyFormatter.ts
+++ b/packages/ui/src/util/hooks/useCurrencyFormatter.ts
@@ -6,13 +6,13 @@ import { getValueByKey } from "../objectUtils"
 const useCurrencyFromatter = () => {
     const state = useBlankState()!
     const format = (
-        balance: BigNumber,
+        amount: BigNumber,
         tokenSymbol: string,
         decimals: number,
         isNativeCurrency = false
     ) => {
         const currencyAmount = toCurrencyAmount(
-            balance || BigNumber.from(0),
+            amount || BigNumber.from(0),
             getValueByKey(
                 state.exchangeRates,
                 isNativeCurrency ? tokenSymbol.toUpperCase() : tokenSymbol,


### PR DESCRIPTION
# Name of the feature/issue
Improve swaps errors and warning communication.

## Description
This PR aims: 
- Improve the swap error messages to match the behavior of the extension regarding these messages.
- Improve the gas price message error.
- Warn the user when the loss of the swap is higher or equal than the 10% using native currency conversion to compare. 
- Fetch exchange rates of new tokens as fast as possible.
- Default to 0 the conversion rate if coingeko response does not have the rate. (Simulates UI behavior and avoid refetching it everytime the user's balance is updated)

**Improved gas price message:**
![balance_low_gas_config](https://user-images.githubusercontent.com/22504074/219157947-3463824c-2908-49ef-978e-ff3e4851a7a7.png)

Warn the user if can't get with the price impact (we don't have the rate to the native currency)

![Unable](https://user-images.githubusercontent.com/22504074/219158313-63268c0d-21ed-4cbb-9f71-f30044302d44.png)

![Unable_dialog](https://user-images.githubusercontent.com/22504074/219158332-0c127f7b-87db-4075-94ce-2cc8b6878f90.png)

Warn the user about the price impact (used pretty low percentages to test the use case)
![high_impact](https://user-images.githubusercontent.com/22504074/219158498-a3b3e47e-fd59-45d7-9616-5a385809443e.png)
![high_impact_dialog](https://user-images.githubusercontent.com/22504074/219158654-86e789bf-542a-4958-871f-46ff28a8f801.png)

