### PR TITLE
[Fix]: check provider status on extension reload

### DIFF
--- a/packages/background/src/controllers/NetworkController.ts
+++ b/packages/background/src/controllers/NetworkController.ts
@@ -68,6 +68,9 @@ export default class NetworkController extends BaseController<NetworkControllerS
             initialState.selectedNetwork || 'goerli'
         );
 
+        //check provider's status
+        this._updateProviderNetworkStatus();
+
         // Set the error handler for the provider to check for network status
         this.provider.on('error', this._updateProviderNetworkStatus);
 
@@ -710,23 +713,18 @@ export default class NetworkController extends BaseController<NetworkControllerS
             // check for eip1559 compatibility
             await this.getEIP1559Compatibility(network.chainId, true);
 
-            // Set the isNetworkChanging flag to false
-            this.store.updateState({
-                isNetworkChanging: false,
-            });
-
-            // Emit NETWORK_CHANGE event
-            this.emit(NetworkEvents.NETWORK_CHANGE, this.network);
-
             // Return network change success
             return true;
         } catch (error) {
-            // Set the isNetworkChanging flag to false
-            this.store.updateState({ isNetworkChanging: false });
-
             // If an error was thrown
             // return network change failure
             return false;
+        } finally {
+            // Set the isNetworkChanging flag to false
+            this.store.updateState({ isNetworkChanging: false });
+
+            // Emit NETWORK_CHANGE event
+            this.emit(NetworkEvents.NETWORK_CHANGE, this.network);
         }
     }
 


### PR DESCRIPTION
# Name of the feature/issue
Check provider status on extension reload

## Description
This PR adds a network provider check in the NetworkController constructor to recalculate its status. Currently a broken provider is fake ""fixed"" reloading the extension. Adding this check, we will have the real provider status even if the network was reloaded. This also submits the Network change status event no matter the provider fails, to sync every extension with the new network chain id.