### PR TITLE
fix/ remove fallback value from dapp gas estimation

### DIFF
--- a/packages/background/src/controllers/BlankProviderController.ts
+++ b/packages/background/src/controllers/BlankProviderController.ts
@@ -483,24 +483,18 @@ export default class BlankProviderController extends BaseController<BlankProvide
                 } as TransactionParams,
             } as TransactionMeta);
 
+            if (!estimation.estimationSucceeded) {
+                throw new Error('gas estimation has failed');
+            }
+
             gasLimit = estimation.gasLimit;
         } catch (error) {
             log.debug('error estimating gas:', error);
-            try {
-                gasLimit = BigNumber.from(
-                    await this._networkController
-                        .getProvider()
-                        .send(JSONRPCMethod.eth_estimateGas, params)
-                );
-            } catch {
-                let { blockGasLimit } = this._gasPricesController.getState();
-                if (!bnGreaterThanZero(blockGasLimit)) {
-                    // London block size 30 millon gas units
-                    // https://ethereum.org/en/developers/docs/gas/#block-size
-                    blockGasLimit = BigNumber.from(30_000_000);
-                }
-                gasLimit = blockGasLimit;
-            }
+            gasLimit = BigNumber.from(
+                await this._networkController
+                    .getProvider()
+                    .send(JSONRPCMethod.eth_estimateGas, params)
+            );
         }
 
         return gasLimit._hex;


### PR DESCRIPTION
# Name of the feature/issue

Remove fallback value from dApp gas estimation

## Description

In the case where the gas estimation RPC call fails, we don't use a fallback value anymore, what we do is throw the error to the dApp.