### PR TITLE
[Feat] Use custom BlockWallet endpoint for coingeko requests

### DIFF
--- a/packages/background/src/controllers/ExchangeRatesController.ts
+++ b/packages/background/src/controllers/ExchangeRatesController.ts
@@ -22,7 +22,7 @@ import httpClient from '../utils/http';
 import {
     getRateService,
     RateService,
-    BaseApiEndpoint,
+    BASE_API_ENDPOINT,
     chainLinkService,
     coingekoService,
 } from '../utils/rateService';
@@ -93,7 +93,14 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
                     });
 
                     this.updateNetworkNativeCurrencyId(network);
-                    await this.updateExchangeRates();
+
+                    //Still use interval manager to avoid multiple request but execute immeditately.
+                    this._exchangeRateFetchIntervalController.tick(
+                        0,
+                        async () => {
+                            await this.updateExchangeRates();
+                        }
+                    );
                 } catch (error) {
                     log.error(error);
                 } finally {
@@ -262,7 +269,7 @@ export class ExchangeRatesController extends BaseController<ExchangeRatesControl
         const tokens = { ...this.staticTokens, ...this.getTokens() };
         const tokenContracts = Object.keys(tokens).join(',');
 
-        const query = `${BaseApiEndpoint}token_price/${this.networkNativeCurrency.coingeckoPlatformId}`;
+        const query = `${BASE_API_ENDPOINT}token_price/${this.networkNativeCurrency.coingeckoPlatformId}`;
 
         return httpClient.request(query, {
             params: {

--- a/packages/background/src/utils/rateService.ts
+++ b/packages/background/src/utils/rateService.ts
@@ -6,6 +6,9 @@ import { RATES_IDS_LIST } from '@block-wallet/chains-assets';
 import CHAINLINK_DATAFEEDS_CONTRACTS from './chain-link/dataFeeds';
 import httpClient from '../utils/http';
 import log from 'loglevel';
+
+export const BASE_API_ENDPOINT = 'https://api.coingecko.com/api/v3/simple/';
+
 interface getRateOptions {
     networkProvider?: StaticJsonRpcProvider;
 }
@@ -17,8 +20,6 @@ export interface RateService {
         options?: getRateOptions
     ): Promise<number>;
 }
-
-export const BaseApiEndpoint = 'https://api.coingecko.com/api/v3/simple/';
 
 export const chainLinkService: RateService = {
     async getRate(currency, symbol, options: getRateOptions = {}) {
@@ -56,7 +57,7 @@ export const chainLinkService: RateService = {
 export const coingekoService: RateService = {
     async getRate(currency, symbol) {
         try {
-            const query = `${BaseApiEndpoint}price`;
+            const query = `${BASE_API_ENDPOINT}price`;
             const currencyApiId = overloadCurrencyApiId(
                 RATES_IDS_LIST[
                     symbol.toUpperCase() as keyof typeof RATES_IDS_LIST

--- a/packages/ui/src/components/AssetsList.tsx
+++ b/packages/ui/src/components/AssetsList.tsx
@@ -104,8 +104,7 @@ const Asset: FunctionComponent<{
 const SubAssetList: FunctionComponent<{ assets: TokenList }> = ({ assets }) => {
     const state = useBlankState()!
 
-    const isLoading =
-        state.isNetworkChanging || state.isRatesChangingAfterNetworkChange
+    const isLoading = state.isNetworkChanging
 
     const [deletedTokens, setDeletedTokens] = useState([] as string[])
     const pushDeleteTokens = (deleteToken: string) => {

--- a/packages/ui/src/components/gas/GasPricesInfo.tsx
+++ b/packages/ui/src/components/gas/GasPricesInfo.tsx
@@ -119,7 +119,6 @@ const GasPricesInfo: FC = () => {
         localeInfo,
         networkNativeCurrency,
         isNetworkChanging,
-        isRatesChangingAfterNetworkChange,
     } = useBlankState()!
 
     const {
@@ -139,10 +138,7 @@ const GasPricesInfo: FC = () => {
         GAS_LIMITS[calculateGasCost]
     )
 
-    const isLoading =
-        isNetworkChanging ||
-        isRatesChangingAfterNetworkChange ||
-        !displayGasPrices
+    const isLoading = isNetworkChanging || !displayGasPrices
 
     return (
         <>

--- a/packages/ui/src/components/token/TokenSummary.tsx
+++ b/packages/ui/src/components/token/TokenSummary.tsx
@@ -43,8 +43,7 @@ const Balances = ({
 }) => {
     const state = useBlankState()!
 
-    const isLoading =
-        state.isNetworkChanging || state.isRatesChangingAfterNetworkChange
+    const isLoading = state.isNetworkChanging
 
     return (
         <>

--- a/packages/ui/src/components/transactions/TransactionsList.tsx
+++ b/packages/ui/src/components/transactions/TransactionsList.tsx
@@ -15,8 +15,7 @@ const TransactionsList: React.FC<{
 }> = ({ transactions }) => {
     const state = useBlankState()!
 
-    const isLoading =
-        state.isNetworkChanging || state.isRatesChangingAfterNetworkChange
+    const isLoading = state.isNetworkChanging
 
     const [transactionCount, setTransactionCount] = useState(() =>
         getInitialCount(transactions)

--- a/packages/ui/src/routes/PopupPage.tsx
+++ b/packages/ui/src/routes/PopupPage.tsx
@@ -158,8 +158,7 @@ const PopupPage = () => {
     const checksumAddress = useSelectedAddressWithChainIdChecksum()
     const [hasErrorDialog, setHasErrorDialog] = useState(!!error)
 
-    const isLoading =
-        state.isNetworkChanging || state.isRatesChangingAfterNetworkChange
+    const isLoading = state.isNetworkChanging
 
     const disabledActions = !isSendEnabled || !state.isUserNetworkOnline
 


### PR DESCRIPTION
# Name of the feature/issue
Use block-wallet endpoints for fetching token exchange rates

## Description
We have identified some performance issues in the coingeko free API so that:
- We will make available a new block-wallet endpoint to fetch tokens rates
- We will not block the extension usage even if the token rates hasn't been yet fetched