### PR TITLE
[Fix]: Sends gas limit estimation

### DIFF
--- a/packages/background/src/controllers/transactions/TransactionController.ts
+++ b/packages/background/src/controllers/transactions/TransactionController.ts
@@ -2487,6 +2487,18 @@ export class TransactionController extends BaseController<
                 error
             );
 
+            //Transaction will fail no matter how much gas the user sets
+            if (
+                error.reason &&
+                error.reason.match(
+                    /Transfer amount must be greater than zero/gi
+                )
+            ) {
+                throw new Error(
+                    'This token only allows transfers bigger than zero.'
+                );
+            }
+
             const hasFixedGasCost =
                 this._networkController.hasChainFixedGasCost(
                     txOrCurrentChainId

--- a/packages/ui/src/components/networks/NetworkDisplay.tsx
+++ b/packages/ui/src/components/networks/NetworkDisplay.tsx
@@ -210,7 +210,7 @@ const NetworkDisplay = ({
                                 }}
                             />
                         </div>
-                        <span className="text-sm font-bold text-ellipsis overflow-hidden whitespace-nowrap">
+                        <span className="text-sm font-bold text-ellipsis overflow-hidden whitespace-nowrap max-w-[190px]">
                             {networkInfo.desc}
                         </span>
                     </div>

--- a/packages/ui/src/routes/send/SendConfirmPage.tsx
+++ b/packages/ui/src/routes/send/SendConfirmPage.tsx
@@ -695,7 +695,8 @@ const SendConfirmPage = () => {
                         disabled={
                             errors.amount !== undefined ||
                             isLoading ||
-                            isGasLoading
+                            isGasLoading ||
+                            inputFocus
                         }
                         onClick={onSubmit}
                     />


### PR DESCRIPTION
# Name of the feature/issue
The gas limit for tokens transfers is throwing wrong values.

## Description
In order to have more accurate gas limit estimations, we added the amount the user is transferring to the estimation request instead of hardcoding the amount to "1". 