### PR TITLE
[Fix] Not enough funds validation in cancel

### DIFF
--- a/packages/ui/src/components/CancelSpeedUpCommon.tsx
+++ b/packages/ui/src/components/CancelSpeedUpCommon.tsx
@@ -478,7 +478,7 @@ const CancelAndSpeedUpComponent = ({
             maxFeePerGas: parseUnits(values.maxFeePerGas || "0", "gwei"),
         }
     }
- 
+
     const notEnoughFunds = currentBalance
         .sub(BigNumber.from(transaction.transactionParams.value ?? "0"))
         .sub(

--- a/packages/ui/src/components/CancelSpeedUpCommon.tsx
+++ b/packages/ui/src/components/CancelSpeedUpCommon.tsx
@@ -478,28 +478,23 @@ const CancelAndSpeedUpComponent = ({
             maxFeePerGas: parseUnits(values.maxFeePerGas || "0", "gwei"),
         }
     }
-
-    const notEnoughFunds =
-        type === "speed up" &&
-        currentBalance
-            .sub(BigNumber.from(transaction.transactionParams.value ?? "0"))
-            .sub(
-                calcGasPrice(transactionType, {
-                    gasLimit: oldGasLimit,
-                    gasPrice: oldGasPrice,
-                    maxFeePerGas: oldMaxFeePerGas,
-                })
-            )
-            .lt(
-                calcGasPrice(transactionType, {
-                    gasLimit: parseUnits(newFees.gasLimit || "0", "wei"),
-                    gasPrice: parseUnits(newFees.gasPrice || "0", "gwei"),
-                    maxFeePerGas: parseUnits(
-                        newFees.maxFeePerGas || "0",
-                        "gwei"
-                    ),
-                })
-            )
+ 
+    const notEnoughFunds = currentBalance
+        .sub(BigNumber.from(transaction.transactionParams.value ?? "0"))
+        .sub(
+            calcGasPrice(transactionType, {
+                gasLimit: oldGasLimit,
+                gasPrice: oldGasPrice,
+                maxFeePerGas: oldMaxFeePerGas,
+            })
+        )
+        .lt(
+            calcGasPrice(transactionType, {
+                gasLimit: parseUnits(newFees.gasLimit || "0", "wei"),
+                gasPrice: parseUnits(newFees.gasPrice || "0", "gwei"),
+                maxFeePerGas: parseUnits(newFees.maxFeePerGas || "0", "gwei"),
+            })
+        )
 
     useEffect(() => {
         if (!notEnoughFunds && error?.type !== "notEnoughFunds") return


### PR DESCRIPTION
# Name of the feature/issue
Not enough funds validation in cancel
## Description
Fix not enough funds validation in cancel as it didn't show before and transaction would fail with error modal