### PR TITLE
[Fix] Migration errors

### DIFF
--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-48.ts
@@ -15,39 +15,6 @@ export default {
         const { availableNetworks } = persistedState.NetworkController;
         const updatedNetworks = { ...availableNetworks };
 
-        updatedNetworks.SCROLL_L1_TESTNET = {
-            name: 'scroll_l1_testnet',
-            desc: 'Scroll L1 Testnet',
-            chainId: 534351,
-            networkVersion: '534351',
-            nativeCurrency: {
-                name: 'Ether',
-                symbol: 'TSETH',
-                decimals: 18,
-            },
-            iconUrls: [
-                'https://raw.githubusercontent.com/block-wallet/assets/master/blockchains/scroll/info/logo.png',
-            ],
-            isCustomNetwork: true,
-            enable: true,
-            test: true,
-            order: 8,
-            features: [FEATURES.SENDS],
-            ens: false,
-            showGasLevels: true,
-            rpcUrls: [`https://prealpha.scroll.io/l1`],
-            blockExplorerUrls: ['https://l1scan.scroll.io/'],
-            blockExplorerName: 'Scroll L1 Explorer',
-            actionsTimeIntervals: {
-                ...SLOW_TESTNET_TIME_INTERVALS_DEFAULT_VALUES,
-            },
-            tornadoIntervals: {
-                depositConfirmations: DEFAULT_TORNADO_CONFIRMATION,
-                derivationsForward: DERIVATIONS_FORWARD,
-            },
-            nativelySupported: true,
-        } as any;
-
         updatedNetworks.SCROLL_L2_TESTNET = {
             name: 'scroll_l2_testnet',
             desc: 'Scroll L2 Testnet',

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-52.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-52.ts
@@ -34,10 +34,7 @@ export default {
             ...updatedNetworks.ZKSYNC_ALPHA_TESTNET,
             showGasLevels: false,
         };
-        updatedNetworks.SCROLL_L1_TESTNET = {
-            ...updatedNetworks.SCROLL_L1_TESTNET,
-            showGasLevels: false,
-        };
+
         updatedNetworks.SCROLL_L2_TESTNET = {
             ...updatedNetworks.SCROLL_L2_TESTNET,
             showGasLevels: false,

--- a/packages/background/src/infrastructure/stores/migrator/migrations/migration-58.ts
+++ b/packages/background/src/infrastructure/stores/migrator/migrations/migration-58.ts
@@ -11,11 +11,6 @@ export default {
         const { availableNetworks } = persistedState.NetworkController;
         const updatedNetworks = { ...availableNetworks };
 
-        updatedNetworks.SCROLL_L1_TESTNET = {
-            ...updatedNetworks.SCROLL_L1_TESTNET,
-            rpcUrls: INITIAL_NETWORKS.SCROLL_L1_TESTNET.rpcUrls,
-        };
-
         updatedNetworks.SCROLL_L2_TESTNET = {
             ...updatedNetworks.SCROLL_L2_TESTNET,
             rpcUrls: INITIAL_NETWORKS.SCROLL_L2_TESTNET.rpcUrls,


### PR DESCRIPTION
# Name of the feature/issue
Migration errors
## Description
Added try/catch to migration process to prevent the extension from being unusable when a migration fails. This caused the popup to load forever and the state to remain broken or outdated. Also removed the logic from old migrations which caused the issue.
![image](https://user-images.githubusercontent.com/11839151/234337597-21d49708-74d9-4420-a756-36a529ede34e.png)

