### PR TITLE
[Fix] EIP-1559 params on Legacy Transactions

### DIFF
--- a/packages/background/src/controllers/transactions/TransactionController.ts
+++ b/packages/background/src/controllers/transactions/TransactionController.ts
@@ -296,8 +296,8 @@ export class TransactionController extends BaseController<
         public config: {
             txHistoryLimit: number;
         } = {
-            txHistoryLimit: 40,
-        }
+                txHistoryLimit: 40,
+            }
     ) {
         super(initialState);
 
@@ -761,6 +761,8 @@ export class TransactionController extends BaseController<
         const feeData = this._gasPricesController.getFeeData(chainId);
 
         if (chainIsEIP1559Compatible) {
+
+
             // Max fee per gas
             if (!transactionMeta.transactionParams.maxFeePerGas) {
                 if (feeData.maxFeePerGas) {
@@ -776,23 +778,13 @@ export class TransactionController extends BaseController<
                         BigNumber.from(feeData.maxPriorityFeePerGas);
                 }
             }
-        } else {
-            // Gas price
-            if (!transactionMeta.transactionParams.gasPrice) {
-                if (feeData.gasPrice) {
-                    transactionMeta.transactionParams.gasPrice = BigNumber.from(
-                        feeData.gasPrice
-                    );
-                }
-            }
-        }
 
-        /**
-         * Checks if the network is compatible with EIP1559 but the
-         * the transaction is legacy and then Transforms the gas configuration
-         * of the legacy transaction to the EIP1559 fee data.
-         */
-        if (chainIsEIP1559Compatible) {
+
+            /**
+             * Checks if the network is compatible with EIP1559 but the
+             * the transaction is legacy and then Transforms the gas configuration
+             * of the legacy transaction to the EIP1559 fee data.
+             */
             if (
                 getTransactionType(transactionMeta.transactionParams) !=
                 TransactionType.FEE_MARKET_EIP1559
@@ -804,7 +796,25 @@ export class TransactionController extends BaseController<
                     transactionMeta.transactionParams.gasPrice;
                 transactionMeta.transactionParams.gasPrice = undefined;
             }
+
+
+        } else {
+            // Gas price
+            if (!transactionMeta.transactionParams.gasPrice) {
+                if (feeData.gasPrice) {
+                    transactionMeta.transactionParams.gasPrice = BigNumber.from(
+                        feeData.gasPrice
+                    );
+                }
+            }
+
+            // If the network is not EIP-1559 compatible, we remove maxPriority and maxFee parameters in case they come with a value, specially from dApps.
+            transactionMeta.transactionParams.maxPriorityFeePerGas = undefined;
+            transactionMeta.transactionParams.maxFeePerGas = undefined;
+
         }
+
+
 
         return transactionMeta;
     }
@@ -861,8 +871,7 @@ export class TransactionController extends BaseController<
 
                     // Subscribe confirmation and rejection listeners
                     this.hub.once(
-                        `${transactionMetaId}:${
-                            waitForConfirmation ? 'confirmed' : 'submitted'
+                        `${transactionMetaId}:${waitForConfirmation ? 'confirmed' : 'submitted'
                         }`,
                         confirmationListener
                     );
@@ -877,8 +886,7 @@ export class TransactionController extends BaseController<
             // Remove confirmation and rejection listeners on promise completion
             confirmationListener &&
                 this.hub.removeListener(
-                    `${transactionMetaId}:${
-                        !waitForConfirmation ? 'submitted' : 'confirmed'
+                    `${transactionMetaId}:${!waitForConfirmation ? 'submitted' : 'confirmed'
                     }`,
                     confirmationListener
                 );
@@ -1005,13 +1013,13 @@ export class TransactionController extends BaseController<
 
             const txParams = isEIP1559
                 ? {
-                      ...baseTxParams,
-                      maxFeePerGas:
-                          transactionMeta.transactionParams.maxFeePerGas,
-                      maxPriorityFeePerGas:
-                          transactionMeta.transactionParams
-                              .maxPriorityFeePerGas,
-                  }
+                    ...baseTxParams,
+                    maxFeePerGas:
+                        transactionMeta.transactionParams.maxFeePerGas,
+                    maxPriorityFeePerGas:
+                        transactionMeta.transactionParams
+                            .maxPriorityFeePerGas,
+                }
                 : baseTxParams;
 
             // delete gasPrice if maxFeePerGas and maxPriorityFeePerGas are set
@@ -1868,7 +1876,7 @@ export class TransactionController extends BaseController<
         // Check for token allowance update
         if (
             transactionMeta.transactionCategory ===
-                TransactionCategories.TOKEN_METHOD_APPROVE &&
+            TransactionCategories.TOKEN_METHOD_APPROVE &&
             transactionMeta.advancedData?.allowance &&
             advancedData?.allowance !== transactionMeta.advancedData?.allowance
         ) {
@@ -2031,7 +2039,7 @@ export class TransactionController extends BaseController<
         return !!transactions.find(
             (t) =>
                 t.transactionParams.nonce ===
-                    transaction.transactionParams.nonce &&
+                transaction.transactionParams.nonce &&
                 compareAddresses(
                     t.transactionParams.from,
                     transaction.transactionParams.from
@@ -2540,7 +2548,7 @@ export class TransactionController extends BaseController<
             .transactions.filter(
                 (t) =>
                     t.transactionCategory ===
-                        TransactionCategories.BLANK_DEPOSIT &&
+                    TransactionCategories.BLANK_DEPOSIT &&
                     t.status !== TransactionStatus.UNAPPROVED &&
                     t.chainId === fromChainId
             );

--- a/packages/background/src/controllers/transactions/TransactionController.ts
+++ b/packages/background/src/controllers/transactions/TransactionController.ts
@@ -296,8 +296,8 @@ export class TransactionController extends BaseController<
         public config: {
             txHistoryLimit: number;
         } = {
-                txHistoryLimit: 40,
-            }
+            txHistoryLimit: 40,
+        }
     ) {
         super(initialState);
 
@@ -761,8 +761,6 @@ export class TransactionController extends BaseController<
         const feeData = this._gasPricesController.getFeeData(chainId);
 
         if (chainIsEIP1559Compatible) {
-
-
             // Max fee per gas
             if (!transactionMeta.transactionParams.maxFeePerGas) {
                 if (feeData.maxFeePerGas) {
@@ -778,7 +776,6 @@ export class TransactionController extends BaseController<
                         BigNumber.from(feeData.maxPriorityFeePerGas);
                 }
             }
-
 
             /**
              * Checks if the network is compatible with EIP1559 but the
@@ -796,8 +793,6 @@ export class TransactionController extends BaseController<
                     transactionMeta.transactionParams.gasPrice;
                 transactionMeta.transactionParams.gasPrice = undefined;
             }
-
-
         } else {
             // Gas price
             if (!transactionMeta.transactionParams.gasPrice) {
@@ -811,10 +806,7 @@ export class TransactionController extends BaseController<
             // If the network is not EIP-1559 compatible, we remove maxPriority and maxFee parameters in case they come with a value, specially from dApps.
             transactionMeta.transactionParams.maxPriorityFeePerGas = undefined;
             transactionMeta.transactionParams.maxFeePerGas = undefined;
-
         }
-
-
 
         return transactionMeta;
     }
@@ -871,7 +863,8 @@ export class TransactionController extends BaseController<
 
                     // Subscribe confirmation and rejection listeners
                     this.hub.once(
-                        `${transactionMetaId}:${waitForConfirmation ? 'confirmed' : 'submitted'
+                        `${transactionMetaId}:${
+                            waitForConfirmation ? 'confirmed' : 'submitted'
                         }`,
                         confirmationListener
                     );
@@ -886,7 +879,8 @@ export class TransactionController extends BaseController<
             // Remove confirmation and rejection listeners on promise completion
             confirmationListener &&
                 this.hub.removeListener(
-                    `${transactionMetaId}:${!waitForConfirmation ? 'submitted' : 'confirmed'
+                    `${transactionMetaId}:${
+                        !waitForConfirmation ? 'submitted' : 'confirmed'
                     }`,
                     confirmationListener
                 );
@@ -1013,13 +1007,13 @@ export class TransactionController extends BaseController<
 
             const txParams = isEIP1559
                 ? {
-                    ...baseTxParams,
-                    maxFeePerGas:
-                        transactionMeta.transactionParams.maxFeePerGas,
-                    maxPriorityFeePerGas:
-                        transactionMeta.transactionParams
-                            .maxPriorityFeePerGas,
-                }
+                      ...baseTxParams,
+                      maxFeePerGas:
+                          transactionMeta.transactionParams.maxFeePerGas,
+                      maxPriorityFeePerGas:
+                          transactionMeta.transactionParams
+                              .maxPriorityFeePerGas,
+                  }
                 : baseTxParams;
 
             // delete gasPrice if maxFeePerGas and maxPriorityFeePerGas are set
@@ -1876,7 +1870,7 @@ export class TransactionController extends BaseController<
         // Check for token allowance update
         if (
             transactionMeta.transactionCategory ===
-            TransactionCategories.TOKEN_METHOD_APPROVE &&
+                TransactionCategories.TOKEN_METHOD_APPROVE &&
             transactionMeta.advancedData?.allowance &&
             advancedData?.allowance !== transactionMeta.advancedData?.allowance
         ) {
@@ -2039,7 +2033,7 @@ export class TransactionController extends BaseController<
         return !!transactions.find(
             (t) =>
                 t.transactionParams.nonce ===
-                transaction.transactionParams.nonce &&
+                    transaction.transactionParams.nonce &&
                 compareAddresses(
                     t.transactionParams.from,
                     transaction.transactionParams.from
@@ -2548,7 +2542,7 @@ export class TransactionController extends BaseController<
             .transactions.filter(
                 (t) =>
                     t.transactionCategory ===
-                    TransactionCategories.BLANK_DEPOSIT &&
+                        TransactionCategories.BLANK_DEPOSIT &&
                     t.status !== TransactionStatus.UNAPPROVED &&
                     t.chainId === fromChainId
             );

--- a/packages/background/test/controllers/transactions/TransactionController.test.ts
+++ b/packages/background/test/controllers/transactions/TransactionController.test.ts
@@ -160,7 +160,7 @@ describe('Transactions Controller', () => {
                 }),
                 estimateGas: () => BigNumber.from('150000'),
                 getGasPrice: () => BigNumber.from('2000000000'),
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getCode: (addresOrName: string) => Promise.resolve('0xabc'),
             });
             sinon.stub(gasPricesController, 'getState').returns({
@@ -185,7 +185,7 @@ describe('Transactions Controller', () => {
         it('Should fallback the gasLimit to the latest block one', async () => {
             sinon.stub(networkController, 'getProvider').returns({
                 ...providerMock,
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getGasPrice: () => BigNumber.from('2000000000'),
                 estimateGas: () => {
                     throw new Error('Error estimating');
@@ -216,7 +216,7 @@ describe('Transactions Controller', () => {
         it('Should fail while trying to estimate gas and return a fallback value', async () => {
             sinon.stub(networkController, 'getProvider').returns({
                 ...providerMock,
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getGasPrice: () => BigNumber.from('2000000000'),
                 estimateGas: () => {
                     throw new Error('Error estimating');
@@ -255,7 +255,7 @@ describe('Transactions Controller', () => {
                 }),
                 estimateGas: () => BigNumber.from('150000'),
                 getGasPrice: () => BigNumber.from('2000000000'),
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getCode: (addresOrName: string) => Promise.resolve('0xabc'),
             });
             sinon.stub(gasPricesController, 'getState').returns({
@@ -280,7 +280,7 @@ describe('Transactions Controller', () => {
         it('Should return the unmodified estimated gasLimit', async () => {
             sinon.stub(networkController, 'getProvider').returns({
                 ...providerMock,
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getGasPrice: () => BigNumber.from('2000000000'),
                 estimateGas: () => BigNumber.from('190000'),
                 getBlock: (block: any) => ({
@@ -309,7 +309,7 @@ describe('Transactions Controller', () => {
         it('Should return the send gas cost', async () => {
             sinon.stub(networkController, 'getProvider').returns({
                 ...providerMock,
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getGasPrice: () => BigNumber.from('2000000000'),
                 estimateGas: () => BigNumber.from('21000'),
                 getBlock: (block: any) => ({
@@ -342,7 +342,7 @@ describe('Transactions Controller', () => {
 
             sinon.stub(networkController, 'getProvider').returns({
                 ...providerMock,
-                on: (event: string, func: Function) => {},
+                on: (event: string, func: Function) => { },
                 getGasPrice: () => BigNumber.from('2000000000'),
                 estimateGas: () => {
                     return BigNumber.from('1200000');
@@ -1130,17 +1130,17 @@ describe('Transactions Controller', () => {
                         return hash ===
                             '0x4930060e5e465f32c78cea9d467b8d7e9176653cd0416040c44af404dac53fed'
                             ? Promise.resolve({
-                                  status: 1,
-                              })
+                                status: 1,
+                            })
                             : Promise.resolve(null);
                     },
                     getTransaction: (hash) => {
                         return hash ===
                             '0x4930060e5e465f32c78cea9d467b8d7e9176653cd0416040c44af404dac53fed'
                             ? Promise.resolve({
-                                  blockNumber: 1,
-                                  timestamp: new Date().getTime() / 1000,
-                              })
+                                blockNumber: 1,
+                                timestamp: new Date().getTime() / 1000,
+                            })
                             : Promise.resolve(null);
                     },
                 });
@@ -1244,17 +1244,17 @@ describe('Transactions Controller', () => {
                         return hash ===
                             '0x4930060e5e465f32c78cea9d467b8d7e9176653cd0416040c44af404dac53fed'
                             ? Promise.resolve({
-                                  status: 1,
-                              })
+                                status: 1,
+                            })
                             : Promise.resolve(null);
                     },
                     getTransaction: (hash) => {
                         return hash ===
                             '0x4930060e5e465f32c78cea9d467b8d7e9176653cd0416040c44af404dac53fed'
                             ? Promise.resolve({
-                                  blockNumber: 1,
-                                  timestamp: new Date().getTime() / 1000,
-                              })
+                                blockNumber: 1,
+                                timestamp: new Date().getTime() / 1000,
+                            })
                             : Promise.resolve(null);
                     },
                 });
@@ -1309,6 +1309,10 @@ describe('Transactions Controller', () => {
                     gasLimit: BigNumber.from(SEND_GAS_COST),
                 })
             );
+
+            sinon.stub(networkController, 'getEIP1559Compatibility').returns(
+                Promise.resolve(true)
+            )
 
             const { transactionMeta } =
                 await transactionController.addTransaction({
@@ -1855,6 +1859,8 @@ describe('Transactions Controller', () => {
             expect(updatedTx).deep.equal({
                 transactionParams: {
                     gasPrice: BigNumber.from('10'),
+                    maxFeePerGas: undefined,
+                    maxPriorityFeePerGas: undefined
                 },
             } as TransactionMeta);
         });


### PR DESCRIPTION
# Name of the feature/issue
EIP-1559 params on Legacy Transactions
## Description
This PR removed EIP-1559 parameters on legacy transactions after we detected that some dApps send both (i.e. [Velocore](https://app.velocore.xyz/swap)) on zkSync (non-EIP1559).