### PR TITLE
[Core] Storage Limit

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -48,6 +48,7 @@
     "permissions": [
         "activeTab",
         "storage",
+        "unlimitedStorage",
         "notifications",
         "https://*.blockwallet.io/*",
         "https://*.etherscan.io/*",


### PR DESCRIPTION
# Name of the feature/issue
Storage Limit
## Description
After receiving some reports of strange behaviors on instances with many accounts, we detected that the state was full of data and exceeded the default limit. While we work on more improvements, the `unlimitedStorage` flag will prevent users from being stuck or rollbacks in wallet actions.