### PR TITLE
[Fix] Value parameter on Allowance transactions

### DIFF
--- a/packages/background/src/controllers/transactions/TransactionController.ts
+++ b/packages/background/src/controllers/transactions/TransactionController.ts
@@ -593,6 +593,8 @@ export class TransactionController extends BaseController<
                     transactionMeta.advancedData = advancedData;
                     transactionMeta.approveAllowanceParams =
                         approveAllowanceParams;
+                    // Ensure that approve transactions do not send anything in the value parameter to prevent potential native asset steal.
+                    transaction.value = undefined;
                 }
 
                 // Push transaction so extension can trigger window without waiting for gas values
@@ -961,6 +963,9 @@ export class TransactionController extends BaseController<
                         transactionMeta.transactionParams.data!
                     );
                 transactionMeta.methodSignature = methodSignature;
+
+                // Ensure that approve transactions do not send anything in the value parameter to prevent potential native asset steal.
+                transactionMeta.transactionParams.value = undefined;
             }
 
             transactionMeta.status = status;


### PR DESCRIPTION
# Name of the feature/issue
Value parameter on Allowance transactions
## Description
We don't display a **Total** transaction value on the allowance approval page because it is only supposed to cost what the fees cost. This translates to the **value** parameter of the transaction having a **zero** or undefined value.

But we received transaction parameters from dApps and parse them without checking the **value**, which caused a potential loss of native assets if the user approved such a transaction.

This PR enforces an undefined value parameter for allowance transactions which should never require a value in the first place.

Credit goes to @jinukaloshaechi who reported it on Immunefi and Discord