### PR TITLE
[Fix] Message on QR code camera screen

### DIFF
--- a/packages/ui/src/routes/hardware-wallet/KeystoneConnectionPage.tsx
+++ b/packages/ui/src/routes/hardware-wallet/KeystoneConnectionPage.tsx
@@ -45,7 +45,7 @@ const KeystoneConnectionPage = () => {
     ) : (
         <HardwareWalletSetupLayout
             title={"Show Keystone QR code"}
-            subtitle={""}
+            subtitle={"The camera is blurred but it won't affect the scanning."}
             buttons={
                 <>
                     <div className="p-8 w-80 flex space-x-5 ml-auto mr-auto">


### PR DESCRIPTION


# Name of the feature/issue
Message on QR code camera screen
## Description
Added a message explaining that the blurred camera won't affect the scanning.

![image](https://github.com/block-wallet/extension/assets/11839151/a5cf93fb-6275-4cff-a90d-e3162365f919)
