### PR TITLE
Fixed NO EIP 1559 test

### DIFF
--- a/packages/background/test/controllers/NetworkController.test.ts
+++ b/packages/background/test/controllers/NetworkController.test.ts
@@ -132,7 +132,7 @@ describe('Network controller', function () {
             });
 
             const shouldBeCompatibleWithEIP155 =
-                await networkController.getEIP1559Compatibility(56, false);
+                await networkController.getEIP1559Compatibility(1101, false);
             expect(shouldBeCompatibleWithEIP155).equal(false);
         });
         it('There is not a value for the chain', async () => {

--- a/packages/background/test/controllers/block-updates/BlockFetchController.test.ts
+++ b/packages/background/test/controllers/block-updates/BlockFetchController.test.ts
@@ -286,7 +286,7 @@ describe('OffChainBlockFetchService', () => {
             expect(_recurrentFetch).not.equal(undefined);
             expect(_recurrentFetch).not.equal(null);
 
-            await wait(700);
+            await wait(1000);
             loopActivated = false;
 
             await errorsPromise;


### PR DESCRIPTION
# Name of the feature/issue
The current test suite fails with at least one test.

## Description

```sh
  1) Network controller
       EIP1559 compatibility
         The chain fee service indicates NO EIP 1559 compatibility:

      AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
    
      at Suite.<anonymous> (test/controllers/NetworkController.test.ts:136:50)
      at Generator.next (<anonymous>)
      at fulfilled (test/controllers/NetworkController.test.ts:28:58)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This is probably due to the check about the baseFee attribute for chainID [56](https://chain-fee.blockwallet.io/v1/fee_data?c=56):

```json
{"blockNumber":"31381181", "blockGasLimit":"140000000", "baseFee":"0", "estimatedBaseFee":"0", "gasPricesLevels":{"slow":{"maxFeePerGas":"1100000000", "maxPriorityFeePerGas":"1100000000"}, "average":{"maxFeePerGas":"3000000000", "maxPriorityFeePerGas":"3000000000"}, "fast":{"maxFeePerGas":"3006000000", "maxPriorityFeePerGas":"3006000000"}}}
```

It's 0 but it's there, so the code consider that chain EIP 1559 compatible.

I changed with [1101](https://chain-fee.blockwallet.io/v1/fee_data?c=1101), that is both not present into the `NO_EIP_1559_NETWORKS` list and the fee service does not contain a baseFee attribute:

```json
{"blockNumber":"5060364", "blockGasLimit":"30000000", "gasPricesLevels":{"slow":{"gasPrice":"451350000"}, "average":{"gasPrice":"531000000"}, "fast":{"gasPrice":"663750000"}}}
```

Another test fails sometimes because it's time dependant:

```sh
  1) OffChainBlockFetchService
       setFetch
         should detect that the service is stuck:

      AssertionError: expected false to equal true
      + expected - actual

      -false
      +true

      at ./packages/background/test/controllers/block-updates/BlockFetchController.test.ts:293:45
      at Generator.next (<anonymous>)
      at fulfilled (test/controllers/block-updates/BlockFetchController.test.ts:28:58)
```

I increased the delay a little bit, but probably a more reliable mechanism is worth to be considered.