### PR TITLE
[Fix] EIP-1559 Integrity check

### DIFF
--- a/packages/background/src/controllers/GasPricesController.ts
+++ b/packages/background/src/controllers/GasPricesController.ts
@@ -234,8 +234,13 @@ export class GasPricesController extends BaseController<GasPricesControllerState
     ): Promise<void> => {
         try {
             const oldGasPriceLevels = this.getGasPricesLevels(chainId);
+
             const isEIP1559Compatible =
-                await this._networkController.getEIP1559Compatibility(chainId);
+                await this._networkController.getEIP1559Compatibility(
+                    chainId,
+                    false,
+                    this.getState().baseFee
+                );
 
             const newGasPriceLevels = await this._fetchFeeData(
                 isEIP1559Compatible,
@@ -962,6 +967,7 @@ export class GasPricesController extends BaseController<GasPricesControllerState
             await this._networkController.getEIP1559Compatibility(
                 chainId,
                 false,
+                this.getState().baseFee,
                 provider
             );
         let gasPriceData: GasPriceData | undefined = undefined;
@@ -1001,7 +1007,8 @@ export class GasPricesController extends BaseController<GasPricesControllerState
  * Fetches the fee's service to get the current gas prices.
  *
  * @param chainId
- * @param isEIP1559Compatible
+ * @param apiCallsDelay
+ * @param apiCallsRetries
  * @returns GasPriceData or undefined
  */
 export const _fetchFeeDataFromService = async (

--- a/packages/background/src/utils/swaps/1inch.ts
+++ b/packages/background/src/utils/swaps/1inch.ts
@@ -18,7 +18,7 @@ import {
     get1InchErrorMessageFromResponse,
     map1InchErrorMessage,
 } from './1inchError';
-import { BigNumber } from 'ethers/lib/ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { ContractSignatureParser } from '@block-wallet/background/controllers/transactions/ContractSignatureParser';
 
 const KLAYTN_MAINNET_CHAIN_ID = 8217;

--- a/packages/background/src/utils/swaps/openOcean.ts
+++ b/packages/background/src/utils/swaps/openOcean.ts
@@ -14,7 +14,7 @@ import {
     SwapRequestParams,
 } from '@block-wallet/background/controllers/SwapController';
 import { formatUnits } from 'ethers/lib/utils';
-import { BigNumber } from 'ethers/lib/ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { ContractSignatureParser } from '@block-wallet/background/controllers/transactions/ContractSignatureParser';
 
 type OpenOceanNetworks = {

--- a/packages/ui/src/components/hardwareWallet/HardwareWalletAccount.tsx
+++ b/packages/ui/src/components/hardwareWallet/HardwareWalletAccount.tsx
@@ -1,6 +1,6 @@
 import { DeviceAccountInfo } from "@block-wallet/background/controllers/AccountTrackerController"
 import classnames from "classnames"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { formatUnits } from "ethers/lib/utils"
 import { useState } from "react"
 import { getAccountBalance } from "../../context/commActions"

--- a/packages/ui/src/util/tokenUtils.ts
+++ b/packages/ui/src/util/tokenUtils.ts
@@ -1,6 +1,6 @@
 import { AccountTokenOrder } from "@block-wallet/background/controllers/AccountTrackerController"
 import { TokenWithBalance } from "../context/hooks/useTokensList"
-import { BigNumber } from "ethers"
+import { BigNumber } from "@ethersproject/bignumber"
 import { Rates } from "@block-wallet/background/controllers/ExchangeRatesController"
 import { formatRounded } from "./formatRounded"
 import { formatUnits } from "ethers/lib/utils"


### PR DESCRIPTION
# Name of the feature/issue
 EIP-1559 Integrity check
## Description
 Added new EIP1559 integrity check to force fetching the value again when we detect inconsistency between the value and the stored baseFee. We detected this situation on some old states from users which tried to perform an operation and received an error.

After checking the state, we noticed that some chains had the EIP-1559 flag with a `false` value when it should be true. The situation was automatically fixed after switching networks but it seems some users only operate with one network so this check should prevent this situation from happening again (i.e. a non EIP network upgrades to EIP-1559)