### PR TITLE
[Fix] Buy Page receive filter

### DIFF
--- a/packages/ui/src/components/token/TokenList.tsx
+++ b/packages/ui/src/components/token/TokenList.tsx
@@ -30,7 +30,7 @@ const TokenList: FC<{
                 return (
                     <div
                         className="cursor-pointer"
-                        key={token.address}
+                        key={token.symbol}
                         onClick={() => onTokenClick(token, setActive)}
                     >
                         <TokenDisplay


### PR DESCRIPTION
# Name of the feature/issue
Bug Page receive filter
## Description
Receive filter was not working due to some html element keys were empty. We changed the key value to always have one.