### PR TITLE
fix: ui resolve invalid URL error when block explorer is removed (#681)

### DIFF
--- a/packages/ui/src/util/getExplorer.ts
+++ b/packages/ui/src/util/getExplorer.ts
@@ -64,6 +64,10 @@ export const generateExplorerLink = (
         return undefined
     }
 
+    if (!network.blockExplorerUrls[0].trim()) {
+        return undefined
+    }
+
     if (type === "tx") {
         return createCustomExplorerLink(value, network.blockExplorerUrls[0])
     } else if (type === "address") {


### PR DESCRIPTION
# Name of the feature/issue
Fixed invalid URL error in BlockWallet (#681)

## Description
When debugging and locating the problem, I found that when the getNetworkFromChainId method returns a value without a browser url, the returned array is not an empty array. The first item in the array is an empty string, which causes the if (!network.blockExplorerUrls || network.blockExplorerUrls.length < 1) section to intercept the abnormal data without intercepting the abnormal data.
![Snipaste_2024-10-16_19-12-50](https://github.com/user-attachments/assets/6474a579-4399-4b4a-9a79-e37543f840aa)

## Solution
Add if (!network.blockExplorerUrls[0].trim()) to intercept abnormal data
