### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See the [Acknowledgments](docs/acknowledgments.md) file for details
     </picture>
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://twitter.com/GetBlockWallet">
+  <a href="https://x.com/GetBlockWallet">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://blockwallet.io/static/images/logo-twitter.svg" />
       <source media="(prefers-color-scheme: light)" srcset="https://blockwallet.io/static/images/logo-twitter-d.svg" />

--- a/packages/background/3rd-party-licenses.txt
+++ b/packages/background/3rd-party-licenses.txt
@@ -7842,7 +7842,7 @@ esrecurse.visit(
 ### License
 
 Copyright (C) 2014 [Yusuke Suzuki](https://github.com/Constellation)
- (twitter: [@Constellation](https://twitter.com/Constellation)) and other contributors.
+ (twitter: [@Constellation](https://x.com/Constellation)) and other contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/packages/ui/3rd-party-licenses.txt
+++ b/packages/ui/3rd-party-licenses.txt
@@ -1026,7 +1026,7 @@ This package contains the following license and notice below:
 
 [![npm version](https://badge.fury.io/js/dom-confetti.svg)](https://www.npmjs.com/package/dom-confetti)
 
-License MIT, copyright [Daniel Lundin](https://twitter.com/danielundin) 2019
+License MIT, copyright [Daniel Lundin](https://x.com/danielundin) 2019
 
 -----------
 

--- a/packages/ui/src/util/constants.ts
+++ b/packages/ui/src/util/constants.ts
@@ -43,7 +43,7 @@ export const LINKS = {
     TELEGRAM: "https://t.me/blockwallet",
     DISCORD: "https://discord.gg/blockwallet",
     GITHUB: "https://github.com/block-wallet/",
-    TWITTER: "https://twitter.com/GetBlockWallet",
+    TWITTER: "https://x.com/GetBlockWallet",
     WEBSITE_BUG_REPORT: "https://blockwallet.io/bug-report.html",
     GITHUB_BUG_REPORT:
         "https://github.com/block-wallet/extension/issues/new?assignees=&labels=&template=bug_report.md&title=",

--- a/packages/ui/webpack/config/webpack.config.js
+++ b/packages/ui/webpack/config/webpack.config.js
@@ -302,7 +302,7 @@ module.exports = function (webpackEnv) {
                 new CssMinimizerPlugin(),
             ],
             // Automatically split vendor and commons
-            // https://twitter.com/wSokra/status/969633336732905474
+            // https://x.com/wSokra/status/969633336732905474
             // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
             splitChunks: {
                 chunks: "all",


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.


